### PR TITLE
make sure the job data is passed unchanged through redis/lua

### DIFF
--- a/get.lua
+++ b/get.lua
@@ -16,8 +16,11 @@ local job = redis.call(
 if not job[1] then
 	return false
 end
-		
-return cjson.encode({
+
+-- if the job data JSON contains empty arrays they would be mangled
+-- by the decoding to a lua table, that's why its tucked into the
+-- json result afterwards.
+return string.gsub(cjson.encode({
     jid          = job[1],
 	klass        = job[2],
     state        = job[3],
@@ -28,10 +31,10 @@ return cjson.encode({
 	expires      = tonumber(job[7]) or 0,
 	retries      = tonumber(job[8]),
 	remaining    = tonumber(job[9]),
-	data         = cjson.decode(job[10]),
+	data         = "PLACEHOLDER_FOR_UNPROCESSED_JOBDATA_JSON",
 	tags         = cjson.decode(job[11]),
     history      = cjson.decode(job[12]),
 	failure      = cjson.decode(job[13] or '{}'),
 	dependents   = redis.call('smembers', 'ql:j:' .. jid .. '-dependents'),
 	dependencies = redis.call('smembers', 'ql:j:' .. jid .. '-dependencies')
-})
+}),'"PLACEHOLDER_FOR_UNPROCESSED_JOBDATA_JSON"' , job[10], 1)

--- a/put.lua
+++ b/put.lua
@@ -32,7 +32,8 @@ end
 local queue    = assert(KEYS[1]               , 'Put(): Key "queue" missing')
 local jid      = assert(ARGV[1]               , 'Put(): Arg "jid" missing')
 local klass    = assert(ARGV[2]               , 'Put(): Arg "klass" missing')
-local data     = assert(cjson.decode(ARGV[3]) , 'Put(): Arg "data" missing or not JSON: '    .. tostring(ARGV[3]))
+local raw_data = ARGV[3]
+local data     = assert(cjson.decode(raw_data) , 'Put(): Arg "data" missing or not JSON: '   .. tostring(raw_data))
 local now      = assert(tonumber(ARGV[4])     , 'Put(): Arg "now" missing or not a number: ' .. tostring(ARGV[4]))
 local delay    = assert(tonumber(ARGV[5])     , 'Put(): Arg "delay" not a number: '          .. tostring(ARGV[5]))
 
@@ -107,7 +108,7 @@ end
 redis.call('hmset', 'ql:j:' .. jid,
     'jid'      , jid,
 	'klass'    , klass,
-    'data'     , cjson.encode(data),
+    'data'     , raw_data,
     'priority' , priority,
     'tags'     , cjson.encode(tags),
     'state'    , ((delay > 0) and 'scheduled') or 'waiting',


### PR DESCRIPTION
If the job data JSON contains empty arrays they are mangled by
the decoding to a lua table. This commit stores and returns the raw
job data without processing it with lua/cjson.

This pull request belongs to seomoz/qless#73 and tries to be a fix for it.

The change to `get.lua` qualifies as a hack and I would be happy for alternative suggestions.

The way I see it there are only two options:
1. Use `cjson.encode` to create the JSON response and squeeze in the raw job_data afterwards (my current approach).
2. Create the whole JSON container manually without cjson which involves quite a lot of string manipulation.
