### PR TITLE
Added a 'worker' parameter to 'put'

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -144,8 +144,8 @@ QlessAPI.timeout = function(now, ...)
   end
 end
 
-QlessAPI.put = function(now, queue, jid, klass, data, delay, ...)
-  return Qless.queue(queue):put(now, jid, klass, data, delay, unpack(arg))
+QlessAPI.put = function(now, me, queue, jid, klass, data, delay, ...)
+  return Qless.queue(queue):put(now, me, jid, klass, data, delay, unpack(arg))
 end
 
 QlessAPI.unfail = function(now, queue, group, count)

--- a/queue.lua
+++ b/queue.lua
@@ -409,7 +409,7 @@ end
 -- -----------------------
 -- Insert a job into the queue with the given priority, tags, delay, klass and
 -- data.
-function QlessQueue:put(now, jid, klass, raw_data, delay, ...)
+function QlessQueue:put(now, worker, jid, klass, raw_data, delay, ...)
   assert(jid  , 'Put(): Arg "jid" missing')
   assert(klass, 'Put(): Arg "klass" missing')
   local data = assert(cjson.decode(raw_data),
@@ -427,7 +427,7 @@ function QlessQueue:put(now, jid, klass, raw_data, delay, ...)
 
   -- Let's see what the old priority and tags were
   local job = Qless.job(jid)
-  local priority, tags, oldqueue, state, failure, retries, worker =
+  local priority, tags, oldqueue, state, failure, retries, oldworker =
     unpack(redis.call('hmget', QlessJob.ns .. jid, 'priority', 'tags',
       'queue', 'state', 'failure', 'retries', 'worker'))
 
@@ -490,18 +490,22 @@ function QlessQueue:put(now, jid, klass, raw_data, delay, ...)
     queue_obj.scheduled.remove(jid)
   end
 
-  -- If this had previously been given out to a worker,
-  -- make sure to remove it from that worker's jobs
-  if worker and worker ~= '' then
-    redis.call('zrem', 'ql:w:' .. worker .. ':jobs', jid)
-    -- We need to inform whatever worker had that job
-    local encoded = cjson.encode({
-      jid    = jid,
-      event  = 'lock_lost',
-      worker = worker
-    })
-    Qless.publish('w:' .. worker, encoded)
-    Qless.publish('log', encoded)
+  -- If this had previously been given out to a worker, make sure to remove it
+  -- from that worker's jobs
+  if oldworker and oldworker ~= '' then
+    redis.call('zrem', 'ql:w:' .. oldworker .. ':jobs', jid)
+    -- If it's a different worker that's putting this job, send a notification
+    -- to the last owner of the job
+    if oldworker ~= worker then
+      -- We need to inform whatever worker had that job
+      local encoded = cjson.encode({
+        jid    = jid,
+        event  = 'lock_lost',
+        worker = oldworker
+      })
+      Qless.publish('w:' .. oldworker, encoded)
+      Qless.publish('log', encoded)
+    end
   end
 
   -- If the job was previously in the 'completed' state, then we should

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -8,8 +8,8 @@ class TestDependencies(TestQless):
     '''Dependency-related tests'''
     def test_unlock(self):
         '''Dependencies unlock their dependents upon completion'''
-        self.lua('put', 0, 'queue', 'a', 'klass', {}, 0)
-        self.lua('put', 0, 'queue', 'b', 'klass', {}, 0, 'depends', ['a'])
+        self.lua('put', 0, 'worker', 'queue', 'a', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'b', 'klass', {}, 0, 'depends', ['a'])
         # Only 'a' should show up
         self.assertEqual(len(self.lua('pop', 1, 'queue', 'worker', 10)), 1)
         self.lua('complete', 2, 'a', 'worker', 'queue', {})
@@ -19,8 +19,8 @@ class TestDependencies(TestQless):
 
     def test_complete_depends(self):
         '''Can also add dependencies upon completion'''
-        self.lua('put', 0, 'queue', 'b', 'klass', {}, 0)
-        self.lua('put', 1, 'queue', 'a', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'b', 'klass', {}, 0)
+        self.lua('put', 1, 'worker', 'queue', 'a', 'klass', {}, 0)
         # Pop 'b', and then complete it it and make it depend on 'a'
         self.lua('pop', 2, 'queue', 'worker', 1)
         self.lua('complete', 3, 'b', 'worker', 'queue', {},
@@ -35,45 +35,61 @@ class TestDependencies(TestQless):
     def test_satisfied_dependencies(self):
         '''If dependencies are already complete, it should be available'''
         # First, let's try with a job that has been explicitly completed
-        self.lua('put', 0, 'queue', 'a', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'a', 'klass', {}, 0)
         self.lua('pop', 1, 'queue', 'worker', 1)
         self.lua('complete', 2, 'a', 'worker', 'queue', {})
         self.assertEqual(self.lua('get', 3, 'a')['state'], 'complete')
         # Now this job should be readily available
-        self.lua('put', 4, 'queue', 'b', 'klass', {}, 0, 'depends', ['a'])
+        self.lua('put', 4, 'worker', 'queue', 'b', 'klass', {}, 0, 'depends', ['a'])
         self.assertEqual(self.lua('get', 5, 'b')['state'], 'waiting')
         self.assertEqual(self.lua('peek', 6, 'queue', 10)[0]['jid'], 'b')
 
     def test_nonexistent_dependencies(self):
         '''If dependencies don't exist, they're assumed completed'''
-        self.lua('put', 0, 'queue', 'b', 'klass', {}, 0, 'depends', ['a'])
+        self.lua('put', 0, 'worker', 'queue', 'b', 'klass', {}, 0, 'depends', ['a'])
         self.assertEqual(self.lua('get', 1, 'b')['state'], 'waiting')
         self.assertEqual(self.lua('peek', 2, 'queue', 10)[0]['jid'], 'b')
 
     def test_cancel_dependency_chain(self):
         '''If an entire dependency chain is cancelled together, it's ok'''
-        self.lua('put', 0, 'queue', 'a', 'klass', {}, 0)
-        self.lua('put', 1, 'queue', 'b', 'klass', {}, 0, 'depends', ['a'])
+        self.lua('put', 0, 'worker', 'queue', 'a', 'klass', {}, 0)
+        self.lua('put', 1, 'worker', 'queue', 'b', 'klass', {}, 0, 'depends', ['a'])
         self.lua('cancel', 2, 'a', 'b')
         self.assertEqual(self.lua('get', 3, 'a'), None)
         self.assertEqual(self.lua('get', 4, 'b'), None)
 
     def test_cancel_incomplete_chain(self):
         '''Cannot bulk cancel if there are additional dependencies'''
-        self.lua('put', 0, 'queue', 'a', 'klass', {}, 0)
-        self.lua('put', 1, 'queue', 'b', 'klass', {}, 0, 'depends', ['a'])
-        self.lua('put', 2, 'queue', 'c', 'klass', {}, 0, 'depends', ['b'])
+        self.lua('put', 0, 'worker', 'queue', 'a', 'klass', {}, 0)
+        self.lua('put', 1, 'worker', 'queue', 'b', 'klass', {}, 0, 'depends', ['a'])
+        self.lua('put', 2, 'worker', 'queue', 'c', 'klass', {}, 0, 'depends', ['b'])
         # Now, we'll only cancel part of this chain and see that it fails
         self.assertRaisesRegexp(redis.ResponseError, r'is a dependency',
             self.lua, 'cancel', 3, 'a', 'b')
+
+    def test_cancel_with_missing_jobs(self):
+        '''If some jobs are already canceled, it's ok'''
+        self.lua('put', 0, 'worker', 'queue', 'a', 'klass', {}, 0)
+        self.lua('put', 1, 'worker', 'queue', 'b', 'klass', {}, 0)
+        self.lua('cancel', 2, 'a', 'b', 'c')
+        self.assertEqual(self.lua('get', 3, 'a'), None)
+        self.assertEqual(self.lua('get', 4, 'b'), None)
+
+    def test_cancel_any_order(self):
+        '''Can bulk cancel jobs independent of the order'''
+        self.lua('put', 0, 'worker', 'queue', 'a', 'klass', {}, 0)
+        self.lua('put', 1, 'worker', 'queue', 'b', 'klass', {}, 0, 'depends', ['a'])
+        self.lua('cancel', 2, 'b', 'a')
+        self.assertEqual(self.lua('get', 3, 'a'), None)
+        self.assertEqual(self.lua('get', 4, 'b'), None)
 
     def test_multiple_dependency(self):
         '''Unlock a job only after all dependencies have been met'''
         jids = map(str, range(10))
         for jid in jids:
-            self.lua('put', jid, 'queue', jid, 'klass', {}, 0)
+            self.lua('put', jid, 'worker', 'queue', jid, 'klass', {}, 0)
         # This job depends on all of the above
-        self.lua('put', 20, 'queue', 'jid', 'klass', {}, 0, 'depends', jids)
+        self.lua('put', 20, 'worker', 'queue', 'jid', 'klass', {}, 0, 'depends', jids)
         for jid in jids:
             self.assertEqual(self.lua('get', 30, 'jid')['state'], 'depends')
             self.lua('pop', 30, 'queue', 'worker', 1)
@@ -85,10 +101,10 @@ class TestDependencies(TestQless):
     def test_dependency_chain(self):
         '''Test out successive unlocking of a dependency chain'''
         jids = map(str, range(10))
-        self.lua('put', 0, 'queue', 0, 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 0, 'klass', {}, 0)
         for jid, dep in zip(jids[1:], jids[:-1]):
             self.lua(
-                'put', jid, 'queue', jid, 'klass', {}, 0, 'depends', [dep])
+                'put', jid, 'worker', 'queue', jid, 'klass', {}, 0, 'depends', [dep])
         # Now, we should successively pop jobs and they as we complete them
         # we should get the next
         for jid in jids:
@@ -99,9 +115,9 @@ class TestDependencies(TestQless):
 
     def test_add_dependency(self):
         '''We can add dependencies if it's already in the 'depends' state'''
-        self.lua('put', 0, 'queue', 'a', 'klass', {}, 0)
-        self.lua('put', 1, 'queue', 'b', 'klass', {}, 0)
-        self.lua('put', 2, 'queue', 'c', 'klass', {}, 0, 'depends', ['a'])
+        self.lua('put', 0, 'worker', 'queue', 'a', 'klass', {}, 0)
+        self.lua('put', 1, 'worker', 'queue', 'b', 'klass', {}, 0)
+        self.lua('put', 2, 'worker', 'queue', 'c', 'klass', {}, 0, 'depends', ['a'])
         self.lua('depends', 3, 'c', 'on', 'b')
         self.assertEqual(self.lua('get', 4, 'c')['dependencies'], ['a', 'b'])
 
@@ -109,9 +125,9 @@ class TestDependencies(TestQless):
         '''We can remove dependencies'''
         jids = map(str, range(10))
         for jid in jids:
-            self.lua('put', jid, 'queue', jid, 'klass', {}, 0)
+            self.lua('put', jid, 'worker', 'queue', jid, 'klass', {}, 0)
         # This job depends on all of the above
-        self.lua('put', 100, 'queue', 'jid', 'klass', {}, 0, 'depends', jids)
+        self.lua('put', 100, 'worker', 'queue', 'jid', 'klass', {}, 0, 'depends', jids)
         # Now, we'll remove dependences one at a time
         for jid in jids:
             self.assertEqual(self.lua('get', 100, 'jid')['state'], 'depends')
@@ -121,10 +137,10 @@ class TestDependencies(TestQless):
 
     def test_reput_dependency(self):
         '''When we put a job with new deps, new replaces old'''
-        self.lua('put', 0, 'queue', 'a', 'klass', {}, 0)
-        self.lua('put', 1, 'queue', 'b', 'klass', {}, 0)
-        self.lua('put', 2, 'queue', 'c', 'klass', {}, 0, 'depends', ['a'])
-        self.lua('put', 3, 'queue', 'c', 'klass', {}, 0, 'depends', ['b'])
+        self.lua('put', 0, 'worker', 'queue', 'a', 'klass', {}, 0)
+        self.lua('put', 1, 'worker', 'queue', 'b', 'klass', {}, 0)
+        self.lua('put', 2, 'worker', 'queue', 'c', 'klass', {}, 0, 'depends', ['a'])
+        self.lua('put', 3, 'worker', 'queue', 'c', 'klass', {}, 0, 'depends', ['b'])
         self.assertEqual(self.lua('get', 4, 'c')['dependencies'], ['b'])
         self.assertEqual(self.lua('get', 5, 'a')['dependents'], {})
         self.assertEqual(self.lua('get', 6, 'b')['dependents'], ['c'])
@@ -139,7 +155,7 @@ class TestDependencies(TestQless):
 
     def test_depends_waiting(self):
         '''Cannot add or remove dependencies if the job is waiting'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.assertRaisesRegexp(redis.ResponseError, r'in the depends state',
             self.lua, 'depends', 0, 'jid', 'on', 'a')
         self.assertRaisesRegexp(redis.ResponseError, r'in the depends state',
@@ -147,7 +163,7 @@ class TestDependencies(TestQless):
 
     def test_depends_scheduled(self):
         '''Cannot add or remove dependencies if the job is scheduled'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 1)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 1)
         self.assertRaisesRegexp(redis.ResponseError, r'in the depends state',
             self.lua, 'depends', 0, 'jid', 'on', 'a')
         self.assertRaisesRegexp(redis.ResponseError, r'in the depends state',
@@ -162,7 +178,7 @@ class TestDependencies(TestQless):
 
     def test_depends_failed(self):
         '''Cannot add or remove dependencies if the job is failed'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('pop', 0, 'queue', 'worker', 10)
         self.lua('fail', 1, 'jid', 'worker', 'group', 'message', {})
         self.assertRaisesRegexp(redis.ResponseError, r'in the depends state',
@@ -172,7 +188,7 @@ class TestDependencies(TestQless):
 
     def test_depends_running(self):
         '''Cannot add or remove dependencies if the job is running'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('pop', 0, 'queue', 'worker', 10)
         self.assertRaisesRegexp(redis.ResponseError, r'in the depends state',
             self.lua, 'depends', 0, 'jid', 'on', 'a')

--- a/test/test_events.py
+++ b/test/test_events.py
@@ -7,7 +7,7 @@ class TestEvents(TestQless):
     '''Check for all the events we expect'''
     def test_track(self):
         '''We should hear chatter about tracking and untracking jobs'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         with self.lua:
             self.lua('track', 0, 'track', 'jid')
         self.assertEqual(self.lua.log, [{
@@ -24,7 +24,7 @@ class TestEvents(TestQless):
 
     def test_track_canceled(self):
         '''Canceling a tracked job should spawn some data'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('track', 0, 'track', 'jid')
         with self.lua:
             self.lua('cancel', 0, 'jid')
@@ -39,7 +39,7 @@ class TestEvents(TestQless):
 
     def test_track_completed(self):
         '''Tracked jobs get extra notifications when they complete'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('track', 0, 'track', 'jid')
         self.lua('pop', 0, 'queue', 'worker', 10)
         with self.lua:
@@ -54,7 +54,7 @@ class TestEvents(TestQless):
 
     def test_track_fail(self):
         '''We should hear chatter when failing a job'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('track', 0, 'track', 'jid')
         self.lua('pop', 0, 'queue', 'worker', 10)
         with self.lua:
@@ -70,7 +70,7 @@ class TestEvents(TestQless):
 
     def test_track_popped(self):
         '''We should hear chatter when popping a tracked job'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('track', 0, 'track', 'jid')
         with self.lua:
             self.lua('pop', 0, 'queue', 'worker', 10)
@@ -81,10 +81,10 @@ class TestEvents(TestQless):
 
     def test_track_put(self):
         '''We should hear chatter when putting a tracked job'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('track', 0, 'track', 'jid')
         with self.lua:
-            self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+            self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.assertEqual(self.lua.log, [{
             'channel': 'ql:log',
             'data': '{"jid":"jid","event":"put","queue":"queue"}'
@@ -95,7 +95,7 @@ class TestEvents(TestQless):
 
     def test_track_stalled(self):
         '''We should hear chatter when a job stalls'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('track', 0, 'track', 'jid')
         job = self.lua('pop', 0, 'queue', 'worker', 10)[0]
         print self.lua('config.get', 0, 'grace-period')
@@ -115,7 +115,7 @@ class TestEvents(TestQless):
     def test_failed_retries(self):
         '''We should hear chatter when a job fails from retries'''
         self.lua('config.set', 0, 'grace-period', 0)
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0, 'retries', 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0, 'retries', 0)
         job = self.lua('pop', 0, 'queue', 'worker', 10)[0]
         with self.lua:
             self.assertEqual(self.lua(
@@ -134,7 +134,7 @@ class TestEvents(TestQless):
 
     def test_advance(self):
         '''We should hear chatter when completing and advancing a job'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('pop', 0, 'queue', 'worker', 10)
         with self.lua:
             self.lua(
@@ -147,7 +147,7 @@ class TestEvents(TestQless):
 
     def test_timeout(self):
         '''We should hear chatter when a job times out'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('pop', 0, 'queue', 'worker', 10)
         with self.lua:
             self.lua('timeout', 0, 'jid')
@@ -162,7 +162,7 @@ class TestEvents(TestQless):
     def test_put(self):
         '''We should hear chatter when a job is put into a queueu'''
         with self.lua:
-            self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+            self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.assertEqual(self.lua.log, [{
             'channel': 'ql:log',
             'data': '{"jid":"jid","event":"put","queue":"queue"}'
@@ -170,10 +170,10 @@ class TestEvents(TestQless):
 
     def test_reput(self):
         '''When we put a popped job into a queue, it informs the worker'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('pop', 0, 'queue', 'worker', 10)
         with self.lua:
-            self.lua('put', 0, 'another', 'jid', 'klass', {}, 10)
+            self.lua('put', 0, 'another', 'another', 'jid', 'klass', {}, 10)
         self.assertEqual(self.lua.log, [{
             'channel': 'ql:log',
             'data': '{"jid":"jid","event":"put","queue":"another"}'
@@ -206,7 +206,7 @@ class TestEvents(TestQless):
 
     def test_cancel_waiting(self):
         '''We should hear chatter about canceling waiting jobs'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         with self.lua:
             self.lua('cancel', 0, 'jid')
         self.assertEqual(self.lua.log, [{
@@ -217,7 +217,7 @@ class TestEvents(TestQless):
 
     def test_cancel_running(self):
         '''We should hear chatter about canceling running jobs'''
-        self.lua('put', 0, 'q', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'q', 'jid', 'klass', {}, 0)
         self.lua('pop', 0, 'q', 'wrk', 10)
         with self.lua:
             self.lua('cancel', 0, 'jid')
@@ -233,8 +233,8 @@ class TestEvents(TestQless):
 
     def test_cancel_depends(self):
         '''We should hear chatter about canceling dependent jobs'''
-        self.lua('put', 0, 'queue', 'a', 'klass', {}, 0)
-        self.lua('put', 0, 'queue', 'b', 'klass', {}, 0, 'depends', ['a'])
+        self.lua('put', 0, 'worker', 'queue', 'a', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'b', 'klass', {}, 0, 'depends', ['a'])
         with self.lua:
             self.lua('cancel', 0, 'b')
         self.assertEqual(self.lua.log, [{
@@ -245,7 +245,7 @@ class TestEvents(TestQless):
 
     def test_cancel_scheduled(self):
         '''We should hear chatter about canceling scheduled jobs'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 10)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 10)
         with self.lua:
             self.lua('cancel', 0, 'jid')
         self.assertEqual(self.lua.log, [{
@@ -256,7 +256,7 @@ class TestEvents(TestQless):
 
     def test_cancel_failed(self):
         '''We should hear chatter about canceling failed jobs'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('pop', 0, 'queue', 'worker', 10)
         self.lua('fail', 0, 'jid', 'worker', 'group', 'message', {})
         with self.lua:
@@ -265,4 +265,16 @@ class TestEvents(TestQless):
             'channel': 'ql:log',
             'data':
                 '{"jid":"jid","queue":"queue","event":"canceled","worker":""}'
+        }])
+
+    def test_move_lock(self):
+        '''We should /not/ get lock lost events for moving a job we own'''
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
+        self.lua('pop', 0, 'queue', 'worker', 10)
+        with self.lua:
+            # Put the job under the same worker who owns it now
+            self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
+        self.assertEqual(self.lua.log, [{
+            'channel': 'ql:log',
+            'data': '{"jid":"jid","event":"put","queue":"queue"}'
         }])

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -32,7 +32,7 @@ class TestJobs(TestQless):
         '''Verify we can list complete jobs'''
         jids = map(str, range(10))
         for jid in jids:
-            self.lua('put', jid, 'queue', jid, 'klass', {}, 0)
+            self.lua('put', jid, 'worker', 'queue', jid, 'klass', {}, 0)
             self.lua('pop', jid, 'queue', 'worker', 10)
             self.lua('complete', jid, jid, 'worker', 'queue', {})
             complete = self.lua('jobs', jid, 'complete')
@@ -43,7 +43,7 @@ class TestJobs(TestQless):
         '''Verify that we can get a list of running jobs in a queue'''
         jids = map(str, range(10))
         for jid in jids:
-            self.lua('put', jid, 'queue', jid, 'klass', {}, 0)
+            self.lua('put', jid, 'worker', 'queue', jid, 'klass', {}, 0)
             self.lua('pop', jid, 'queue', 'worker', 10)
             running = self.lua('jobs', jid, 'running', 'queue')
             self.assertEqual(len(running), int(jid) + 1)
@@ -54,7 +54,7 @@ class TestJobs(TestQless):
         self.lua('config.set', 0, 'heartbeat', 10)
         jids = map(str, range(10))
         for jid in jids:
-            self.lua('put', jid, 'queue', jid, 'klass', {}, 0)
+            self.lua('put', jid, 'worker', 'queue', jid, 'klass', {}, 0)
             self.lua('pop', jid, 'queue', 'worker', 10)
             stalled = self.lua('jobs', int(jid) + 20, 'stalled', 'queue')
             self.assertEqual(len(stalled), int(jid) + 1)
@@ -64,18 +64,18 @@ class TestJobs(TestQless):
         '''Verify that we can get a list of scheduled jobs in a queue'''
         jids = map(str, range(1, 11))
         for jid in jids:
-            self.lua('put', jid, 'queue', jid, 'klass', {}, jid)
+            self.lua('put', jid, 'worker', 'queue', jid, 'klass', {}, jid)
             scheduled = self.lua('jobs', 0, 'scheduled', 'queue')
             self.assertEqual(len(scheduled), int(jid))
             self.assertEqual(scheduled[-1], jid)
 
     def test_depends(self):
         '''Verify that we can get a list of dependent jobs in a queue'''
-        self.lua('put', 0, 'queue', 'a', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'a', 'klass', {}, 0)
         jids = map(str, range(0, 10))
         for jid in jids:
             self.lua(
-                'put', jid, 'queue', jid, 'klass', {}, 0, 'depends', ['a'])
+                'put', jid, 'worker', 'queue', jid, 'klass', {}, 0, 'depends', ['a'])
             depends = self.lua('jobs', 0, 'depends', 'queue')
             self.assertEqual(len(depends), int(jid) + 1)
             self.assertEqual(depends[-1], jid)
@@ -102,14 +102,14 @@ class TestJobs(TestQless):
 
     def test_scheduled_waiting(self):
         '''Jobs that were scheduled but are ready shouldn't be in scheduled'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 10)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 10)
         self.assertEqual(len(self.lua('jobs', 20, 'scheduled', 'queue')), 0)
 
     def test_pagination_complete(self):
         '''Jobs should be able to provide paginated results for complete'''
         jids = map(str, range(100))
         for jid in jids:
-            self.lua('put', jid, 'queue', jid, 'klass', {}, 0)
+            self.lua('put', jid, 'worker', 'queue', jid, 'klass', {}, 0)
             self.lua('pop', jid, 'queue', 'worker', 10)
             self.lua('complete', jid, jid, 'worker', 'queue', {})
         # Get two pages and ensure they're what we expect
@@ -124,7 +124,7 @@ class TestJobs(TestQless):
         jids = map(str, range(100))
         self.lua('config.set', 0, 'heartbeat', 1000)
         for jid in jids:
-            self.lua('put', jid, 'queue', jid, 'klass', {}, 0)
+            self.lua('put', jid, 'worker', 'queue', jid, 'klass', {}, 0)
             self.lua('pop', jid, 'queue', 'worker', 10)
         # Get two pages and ensure they're what we expect
         self.assertEqual(
@@ -155,7 +155,7 @@ class TestQueue(TestQless):
         '''Discern stalled job counts correctly'''
         expected = dict(self.expected)
         expected['stalled'] = 1
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         job = self.lua('pop', 1, 'queue', 'worker', 10)[0]
         expires = job['expires'] + 10
         self.assertEqual(self.lua('queues', expires, 'queue'), expected)
@@ -165,7 +165,7 @@ class TestQueue(TestQless):
         '''Discern waiting job counts correctly'''
         expected = dict(self.expected)
         expected['waiting'] = 1
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.assertEqual(self.lua('queues', 0, 'queue'), expected)
         self.assertEqual(self.lua('queues', 0), [expected])
 
@@ -173,7 +173,7 @@ class TestQueue(TestQless):
         '''Discern running job counts correctly'''
         expected = dict(self.expected)
         expected['running'] = 1
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('pop', 1, 'queue', 'worker', 10)
         self.assertEqual(self.lua('queues', 0, 'queue'), expected)
         self.assertEqual(self.lua('queues', 0), [expected])
@@ -183,8 +183,8 @@ class TestQueue(TestQless):
         expected = dict(self.expected)
         expected['depends'] = 1
         expected['waiting'] = 1
-        self.lua('put', 0, 'queue', 'a', 'klass', {}, 0)
-        self.lua('put', 0, 'queue', 'b', 'klass', {}, 0, 'depends', ['a'])
+        self.lua('put', 0, 'worker', 'queue', 'a', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'b', 'klass', {}, 0, 'depends', ['a'])
         self.assertEqual(self.lua('queues', 0, 'queue'), expected)
         self.assertEqual(self.lua('queues', 0), [expected])
 
@@ -192,7 +192,7 @@ class TestQueue(TestQless):
         '''Discern scheduled job counts correctly'''
         expected = dict(self.expected)
         expected['scheduled'] = 1
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 10)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 10)
         self.assertEqual(self.lua('queues', 0, 'queue'), expected)
         self.assertEqual(self.lua('queues', 0), [expected])
 
@@ -216,7 +216,7 @@ class TestQueue(TestQless):
         '''Can pause and unpause a queue'''
         jids = map(str, range(10))
         for jid in jids:
-            self.lua('put', 0, 'queue', jid, 'klass', {}, 0)
+            self.lua('put', 0, 'worker', 'queue', jid, 'klass', {}, 0)
         # After pausing, we can't get the jobs, and the state reflects it
         self.lua('pause', 0, 'queue')
         self.assertEqual(len(self.lua('pop', 0, 'queue', 'worker', 100)), 0)
@@ -232,7 +232,7 @@ class TestQueue(TestQless):
 
     def test_advance(self):
         '''When advancing a job to a new queue, queues should know about it'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('pop', 0, 'queue', 'worker', 10)
         self.lua('complete', 0, 'jid', 'worker', 'queue', {}, 'next', 'another')
         expected = dict(self.expected)
@@ -253,7 +253,7 @@ class TestQueue(TestQless):
         '''When checking counts, jobs that /were/ scheduled can be waiting'''
         expected = dict(self.expected)
         expected['waiting'] = 1
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 10)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 10)
         self.assertEqual(self.lua('queues', 20), [expected])
         self.assertEqual(self.lua('queues', 20, 'queue'), expected)
 
@@ -304,7 +304,7 @@ class TestPut(TestQless):
 
     def test_basic(self):
         '''We should be able to put and get jobs'''
-        jid = self.lua('put', 12345, 'queue', 'jid', 'klass', {}, 0)
+        jid = self.lua('put', 12345, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.assertEqual(jid, 'jid')
         # Now we should be able to verify the data we get back
         self.assertEqual(self.lua('get', 12345, 'jid'), {
@@ -330,12 +330,12 @@ class TestPut(TestQless):
         '''We should be able to provide an array as data'''
         # In particular, an empty array should be acceptable, and /not/
         # transformed into a dictionary when it returns
-        self.lua('put', 12345, 'queue', 'jid', 'klass', [], 0)
+        self.lua('put', 12345, 'worker', 'queue', 'jid', 'klass', [], 0)
         self.assertEqual(self.lua('get', 12345, 'jid')['data'], '[]')
 
     def test_put_delay(self):
         '''When we put a job with a delay, it's reflected in its data'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 1)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 1)
         self.assertEqual(self.lua('get', 0, 'jid')['state'], 'scheduled')
         # After the delay, we should be able to pop
         self.assertEqual(self.lua('pop', 0, 'queue', 'worker', 10), {})
@@ -343,32 +343,32 @@ class TestPut(TestQless):
 
     def test_put_retries(self):
         '''Reflects changes to 'retries' '''
-        self.lua('put', 12345, 'queue', 'jid', 'klass', {}, 0, 'retries', 2)
+        self.lua('put', 12345, 'worker', 'queue', 'jid', 'klass', {}, 0, 'retries', 2)
         self.assertEqual(self.lua('get', 12345, 'jid')['retries'], 2)
         self.assertEqual(self.lua('get', 12345, 'jid')['remaining'], 2)
 
     def test_put_tags(self):
         '''When we put a job with tags, it's reflected in its data'''
-        self.lua('put', 12345, 'queue', 'jid', 'klass', {}, 0, 'tags', ['foo'])
+        self.lua('put', 12345, 'worker', 'queue', 'jid', 'klass', {}, 0, 'tags', ['foo'])
         self.assertEqual(self.lua('get', 12345, 'jid')['tags'], ['foo'])
 
     def test_put_priority(self):
         '''When we put a job with priority, it's reflected in its data'''
-        self.lua('put', 12345, 'queue', 'jid', 'klass', {}, 0, 'priority', 1)
+        self.lua('put', 12345, 'worker', 'queue', 'jid', 'klass', {}, 0, 'priority', 1)
         self.assertEqual(self.lua('get', 12345, 'jid')['priority'], 1)
 
     def test_put_depends(self):
         '''Dependencies are reflected in job data'''
-        self.lua('put', 12345, 'queue', 'a', 'klass', {}, 0)
-        self.lua('put', 12345, 'queue', 'b', 'klass', {}, 0, 'depends', ['a'])
+        self.lua('put', 12345, 'worker', 'queue', 'a', 'klass', {}, 0)
+        self.lua('put', 12345, 'worker', 'queue', 'b', 'klass', {}, 0, 'depends', ['a'])
         self.assertEqual(self.lua('get', 12345, 'a')['dependents'], ['b'])
         self.assertEqual(self.lua('get', 12345, 'b')['dependencies'], ['a'])
         self.assertEqual(self.lua('get', 12345, 'b')['state'], 'depends')
 
     def test_move(self):
         '''Move is described in terms of puts.'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {'foo': 'bar'}, 0)
-        self.lua('put', 0, 'other', 'jid', 'klass', {'foo': 'bar'}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {'foo': 'bar'}, 0)
+        self.lua('put', 0, 'worker', 'other', 'jid', 'klass', {'foo': 'bar'}, 0)
         self.assertEqual(self.lua('get', 1, 'jid'), {
             'data': '{"foo": "bar"}',
             'dependencies': {},
@@ -397,24 +397,24 @@ class TestPut(TestQless):
             ('retries', 2, 3)]:
             # First, when not overriding the value, it should stay the sam3
             # even after moving
-            self.lua('put', 0, 'queue', key, 'klass', {}, 0, key, value)
-            self.lua('put', 0, 'other', key, 'klass', {}, 0)
+            self.lua('put', 0, 'worker', 'queue', key, 'klass', {}, 0, key, value)
+            self.lua('put', 0, 'worker', 'other', key, 'klass', {}, 0)
             self.assertEqual(self.lua('get', 0, key)[key], value)
             # But if we override it, it should be updated
-            self.lua('put', 0, 'queue', key, 'klass', {}, 0, key, update)
+            self.lua('put', 0, 'worker', 'queue', key, 'klass', {}, 0, key, update)
             self.assertEqual(self.lua('get', 0, key)[key], update)
 
         # Updating dependecies has to be special-cased a little bit. Without
         # overriding dependencies, they should be carried through the move
-        self.lua('put', 0, 'queue', 'a', 'klass', {}, 0)
-        self.lua('put', 0, 'queue', 'b', 'klass', {}, 0)
-        self.lua('put', 0, 'queue', 'c', 'klass', {}, 0, 'depends', ['a'])
-        self.lua('put', 0, 'other', 'c', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'a', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'b', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'c', 'klass', {}, 0, 'depends', ['a'])
+        self.lua('put', 0, 'worker', 'other', 'c', 'klass', {}, 0)
         self.assertEqual(self.lua('get', 0, 'a')['dependents'], ['c'])
         self.assertEqual(self.lua('get', 0, 'b')['dependents'], {})
         self.assertEqual(self.lua('get', 0, 'c')['dependencies'], ['a'])
         # But if we move and update depends, then it should correctly reflect
-        self.lua('put', 0, 'queue', 'c', 'klass', {}, 0, 'depends', ['b'])
+        self.lua('put', 0, 'worker', 'queue', 'c', 'klass', {}, 0, 'depends', ['b'])
         self.assertEqual(self.lua('get', 0, 'a')['dependents'], {})
         self.assertEqual(self.lua('get', 0, 'b')['dependents'], ['c'])
         self.assertEqual(self.lua('get', 0, 'c')['dependencies'], ['b'])
@@ -437,7 +437,7 @@ class TestPeek(TestQless):
         '''Can peek at a single waiting job'''
         # No jobs for an empty queue
         self.assertEqual(self.lua('peek', 0, 'foo', 10), {})
-        self.lua('put', 0, 'foo', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'foo', 'jid', 'klass', {}, 0)
         # And now we should see a single job
         self.assertEqual(self.lua('peek', 1, 'foo', 10), [{
             'data': '{}',
@@ -458,7 +458,7 @@ class TestPeek(TestQless):
             'worker': u''
         }])
         # With several jobs in the queue, we should be able to see more
-        self.lua('put', 2, 'foo', 'jid2', 'klass', {}, 0)
+        self.lua('put', 2, 'worker', 'foo', 'jid2', 'klass', {}, 0)
         self.assertEqual([o['jid'] for o in self.lua('peek', 3, 'foo', 10)], [
             'jid', 'jid2'])
 
@@ -467,7 +467,7 @@ class TestPeek(TestQless):
         # We'll inserts some jobs with different priorities
         for jid in xrange(-10, 10):
             self.lua(
-                'put', 0, 'queue', jid, 'klass', {}, 0, 'priority', jid)
+                'put', 0, 'worker', 'queue', jid, 'klass', {}, 0, 'priority', jid)
 
         # Peek at the jobs, and they should be in the right order
         jids = [job['jid'] for job in self.lua('peek', 1, 'queue', 100)]
@@ -477,14 +477,14 @@ class TestPeek(TestQless):
         '''Honor the time that jobs were put, priority constant'''
         # Put 100 jobs on with different times
         for time in xrange(100):
-            self.lua('put', time, 'queue', time, 'klass', {}, 0)
+            self.lua('put', time, 'worker', 'queue', time, 'klass', {}, 0)
         jids = [job['jid'] for job in self.lua('peek', 200, 'queue', 100)]
         self.assertEqual(jids, map(str, range(100)))
 
     def test_move(self):
         '''When we move a job, it should be visible in the new, not old'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
-        self.lua('put', 0, 'other', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'other', 'jid', 'klass', {}, 0)
         self.assertEqual(self.lua('peek', 1, 'queue', 10), {})
         self.assertEqual(self.lua('peek', 1, 'other', 10)[0]['jid'], 'jid')
 
@@ -495,8 +495,8 @@ class TestPeek(TestQless):
 
     def test_priority_update(self):
         '''We can change a job's priority'''
-        self.lua('put', 0, 'queue', 'a', 'klass', {}, 0, 'priority', 0)
-        self.lua('put', 0, 'queue', 'b', 'klass', {}, 0, 'priority', 1)
+        self.lua('put', 0, 'worker', 'queue', 'a', 'klass', {}, 0, 'priority', 0)
+        self.lua('put', 0, 'worker', 'queue', 'b', 'klass', {}, 0, 'priority', 1)
         self.assertEqual(['b', 'a'],
             [j['jid'] for j in self.lua('peek', 0, 'queue', 100)])
         self.lua('priority', 0, 'a', 2)
@@ -523,7 +523,7 @@ class TestPop(TestQless):
         # If the queue is empty, you get no jobs
         self.assertEqual(self.lua('pop', 0, 'queue', 'worker', 10), {})
         # With job put, we can get one back
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.assertEqual(self.lua('pop', 1, 'queue', 'worker', 1), [{
             'data': '{}',
             'dependencies': {},
@@ -546,7 +546,7 @@ class TestPop(TestQless):
     def test_pop_many(self):
         '''We should be able to pop off many jobs'''
         for jid in range(10):
-            self.lua('put', jid, 'queue', jid, 'klass', {}, 0)
+            self.lua('put', jid, 'worker', 'queue', jid, 'klass', {}, 0)
         # This should only pop the first 7
         self.assertEqual(
             [job['jid'] for job in self.lua('pop', 100, 'queue', 'worker', 7)],
@@ -561,7 +561,7 @@ class TestPop(TestQless):
         # We'll inserts some jobs with different priorities
         for jid in xrange(-10, 10):
             self.lua(
-                'put', 0, 'queue', jid, 'klass', {}, 0, 'priority', jid)
+                'put', 0, 'worker', 'queue', jid, 'klass', {}, 0, 'priority', jid)
 
         # Peek at the jobs, and they should be in the right order
         jids = [job['jid'] for job in self.lua('pop', 1, 'queue', 'worker', 100)]
@@ -571,14 +571,14 @@ class TestPop(TestQless):
         '''Honor the time jobs were inserted, priority held constant'''
         # Put 100 jobs on with different times
         for time in xrange(100):
-            self.lua('put', time, 'queue', time, 'klass', {}, 0)
+            self.lua('put', time, 'worker', 'queue', time, 'klass', {}, 0)
         jids = [job['jid'] for job in self.lua('pop', 200, 'queue', 'worker', 100)]
         self.assertEqual(jids, map(str, range(100)))
 
     def test_move(self):
         '''When we move a job, it should be visible in the new, not old'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
-        self.lua('put', 0, 'other', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'other', 'jid', 'klass', {}, 0)
         self.assertEqual(self.lua('pop', 1, 'queue', 'worker', 10), {})
         self.assertEqual(self.lua('pop', 1, 'other', 'worker', 10)[0]['jid'], 'jid')
 
@@ -586,7 +586,7 @@ class TestPop(TestQless):
         '''We can control the maxinum number of jobs available in a queue'''
         self.lua('config.set', 0, 'queue-max-concurrency', 5)
         for jid in xrange(10):
-            self.lua('put', jid, 'queue', jid, 'klass', {}, 0)
+            self.lua('put', jid, 'worker', 'queue', jid, 'klass', {}, 0)
         self.assertEqual(len(self.lua('pop', 10, 'queue', 'worker', 10)), 5)
         # But as we complete the jobs, we can pop more
         for jid in xrange(5):
@@ -599,7 +599,7 @@ class TestPop(TestQless):
         # We'll put and pop a bunch of jobs, then restruct concurrency and
         # validate that jobs can't be popped until we dip below that level
         for jid in xrange(100):
-            self.lua('put', jid, 'queue', jid, 'klass', {}, 0)
+            self.lua('put', jid, 'worker', 'queue', jid, 'klass', {}, 0)
         self.lua('pop', 100, 'queue', 'worker', 10)
         self.lua('config.set', 100, 'queue-max-concurrency', 5)
         for jid in xrange(6):
@@ -614,7 +614,7 @@ class TestPop(TestQless):
         '''Stalled jobs can still be popped with max concurrency'''
         self.lua('config.set', 0, 'queue-max-concurrency', 1)
         self.lua('config.set', 0, 'grace-period', 0)
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0, 'retries', 5)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0, 'retries', 5)
         job = self.lua('pop', 0, 'queue', 'worker', 10)[0]
         job = self.lua('pop', job['expires'] + 10, 'queue', 'worker', 10)[0]
         self.assertEqual(job['jid'], 'jid')
@@ -623,8 +623,8 @@ class TestPop(TestQless):
     def test_fail_max_concurrency(self):
         '''Failing a job makes space for a job in a queue with concurrency'''
         self.lua('config.set', 0, 'queue-max-concurrency', 1)
-        self.lua('put', 0, 'queue', 'a', 'klass', {}, 0)
-        self.lua('put', 1, 'queue', 'b', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'a', 'klass', {}, 0)
+        self.lua('put', 1, 'worker', 'queue', 'b', 'klass', {}, 0)
         self.lua('pop', 2, 'queue', 'worker', 10)
         self.lua('fail', 3, 'a', 'worker', 'group', 'message', {})
         job = self.lua('pop', 4, 'queue', 'worker', 10)[0]

--- a/test/test_recurring.py
+++ b/test/test_recurring.py
@@ -95,7 +95,7 @@ class TestRecurring(TestQless):
     def test_priority(self):
         '''Recurring jobs can be given priority'''
         # Put one job with low priority
-        self.lua('put', 0, 'queue', 'low', 'klass', {}, 0, 'priority', 0)
+        self.lua('put', 0, 'worker', 'queue', 'low', 'klass', {}, 0, 'priority', 0)
         self.lua('recur', 0, 'queue', 'high', 'klass', {},
             'interval', 60, 0, 'priority', 10)
         jobs = self.lua('pop', 0, 'queue', 'worker', 10)

--- a/test/test_stats.py
+++ b/test/test_stats.py
@@ -23,7 +23,7 @@ class TestStats(TestQless):
         # times to ensure that we know stats about how long they've waited
         jids = map(str, range(20))
         for jid in jids:
-            self.lua('put', 0, 'queue', jid, 'klass', {}, 0)
+            self.lua('put', 0, 'worker', 'queue', jid, 'klass', {}, 0)
         for jid in jids:
             self.lua('pop', jid, 'queue', 'worker', 1)
 
@@ -40,7 +40,7 @@ class TestStats(TestQless):
         # we'll complete them at different times and check the computed stats
         jids = map(str, range(20))
         for jid in jids:
-            self.lua('put', 0, 'queue', jid, 'klass', {}, 0)
+            self.lua('put', 0, 'worker', 'queue', jid, 'klass', {}, 0)
             self.lua('pop', 0, 'queue', 'worker', 1)
         for jid in jids:
             self.lua('complete', jid, jid, 'worker', 'queue', {})
@@ -57,7 +57,7 @@ class TestStats(TestQless):
         # The distinction here between 'failed' and 'failure' is that 'failed'
         # is the number of jobs that are currently failed, as opposed to the
         # number of times a job has failed in that queue
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('pop', 0, 'queue', 'worker', 1)
         self.lua('fail', 0, 'jid', 'worker', 'group', 'message', {})
         stats = self.lua('stats', 0, 'queue', 0)
@@ -66,14 +66,14 @@ class TestStats(TestQless):
 
         # If we put the job back in a queue, we don't see any failed jobs,
         # but we still see a failure
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         stats = self.lua('stats', 0, 'queue', 0)
         self.assertEqual(stats['failed'], 0)
         self.assertEqual(stats['failures'], 1)
 
     def test_failed_cancel(self):
         '''If we fail a job, and then cancel it, stats reflects 0 failed job'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('pop', 0, 'queue', 'worker', 1)
         self.lua('fail', 0, 'jid', 'worker', 'group', 'message', {})
         self.lua('cancel', 0, 'jid')
@@ -84,7 +84,7 @@ class TestStats(TestQless):
     def test_retries(self):
         '''It correctly tracks retries in a queue'''
         self.lua('config.set', 0, 'heartbeat', '-10')
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('pop', 0, 'queue', 'worker', 1)
         self.assertEqual(self.lua('stats', 0, 'queue', 0)['retries'], 0)
         self.lua('pop', 0, 'queue', 'worker', 1)
@@ -92,17 +92,17 @@ class TestStats(TestQless):
 
     def test_original_day(self):
         '''It updates stats for the original day of stats'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('pop', 0, 'queue', 'worker', 1)
         self.lua('fail', 0, 'jid', 'worker', 'group', 'message', {})
         # Put it somehwere 1.5 days later
-        self.lua('put', 129600, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 129600, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.assertEqual(self.lua('stats', 0, 'queue', 0)['failed'], 0)
         self.assertEqual(self.lua('stats', 0, 'queue', 129600)['failed'], 0)
 
     def test_failed_retries(self):
         '''It updates stats for jobs failed from retries'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0, 'retries', 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0, 'retries', 0)
         self.lua('pop', 1, 'queue', 'worker', 10)
         self.lua('retry', 3, 'jid', 'queue', 'worker')
         self.assertEqual(self.lua('stats', 0, 'queue', 0)['failed'], 1)
@@ -113,7 +113,7 @@ class TestStats(TestQless):
         '''Can cancel job that has been failed from retries through pop'''
         self.lua('config.set', 0, 'heartbeat', -10)
         self.lua('config.set', 0, 'grace-period', 0)
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0, 'retries', 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0, 'retries', 0)
         self.lua('pop', 1, 'queue', 'worker', 10)
         self.lua('pop', 2, 'queue', 'worker', 10)
         self.assertEqual(self.lua('stats', 0, 'queue', 0)['failed'], 1)

--- a/test/test_tag.py
+++ b/test/test_tag.py
@@ -25,39 +25,39 @@ class TestTag(TestQless):
 
     def test_add(self):
         '''Add a tag'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('tag', 0, 'add', 'jid', 'foo')
         self.assertEqual(self.lua('get', 0, 'jid')['tags'], ['foo'])
 
     def test_remove(self):
         '''Remove a tag'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0, 'tags', ['foo'])
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0, 'tags', ['foo'])
         self.lua('tag', 0, 'remove', 'jid', 'foo')
         self.assertEqual(self.lua('get', 0, 'jid')['tags'], {})
 
     def test_add_existing(self):
         '''We shouldn't double-add tags that already exist for the job'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0, 'tags', ['foo'])
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0, 'tags', ['foo'])
         self.lua('tag', 0, 'add', 'jid', 'foo')
         self.assertEqual(self.lua('get', 0, 'jid')['tags'], ['foo'])
 
     def test_remove_nonexistent(self):
         '''Removing a nonexistent tag from a job is ok'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0, 'tags', ['foo'])
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0, 'tags', ['foo'])
         self.lua('tag', 0, 'remove', 'jid', 'bar')
         self.assertEqual(self.lua('get', 0, 'jid')['tags'], ['foo'])
 
     def test_add_multiple(self):
         '''Adding the same tag twice at the same time yields no duplicates'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('tag', 0, 'add', 'jid', 'foo', 'foo', 'foo')
         self.assertEqual(self.lua('get', 0, 'jid')['tags'], ['foo'])
 
     def test_get(self):
         '''Should be able to get jobs taggs with a particular tag'''
-        self.lua('put', 0, 'queue', 'foo', 'klass', {}, 0,
+        self.lua('put', 0, 'worker', 'queue', 'foo', 'klass', {}, 0,
             'tags', ['foo', 'both'])
-        self.lua('put', 0, 'queue', 'bar', 'klass', {}, 0,
+        self.lua('put', 0, 'worker', 'queue', 'bar', 'klass', {}, 0,
             'tags', ['bar', 'both'])
         self.assertEqual(
             self.lua('tag', 0, 'get', 'foo', 0, 10)['jobs'], ['foo'])
@@ -68,7 +68,7 @@ class TestTag(TestQless):
 
     def test_get_add(self):
         '''When adding a tag, it should be available for searching'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.assertEqual(
             self.lua('tag', 0, 'get', 'foo', 0, 10)['jobs'], {})
         self.lua('tag', 0, 'add', 'jid', 'foo')
@@ -77,7 +77,7 @@ class TestTag(TestQless):
 
     def test_order(self):
         '''It should preserve the order of the tags'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         tags = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
         for tag in tags:
             self.lua('tag', 0, 'add', 'jid', tag)
@@ -92,7 +92,7 @@ class TestTag(TestQless):
 
     def test_cancel(self):
         '''When a job is canceled, it's not found in tags'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0, 'tags', ['foo'])
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0, 'tags', ['foo'])
         self.assertEqual(
             self.lua('tag', 0, 'get', 'foo', 0, 10)['jobs'], ['jid'])
         self.lua('cancel', 0, 'jid')
@@ -102,13 +102,13 @@ class TestTag(TestQless):
     def test_expired_jobs(self):
         '''When a job expires, it's removed from its tags'''
         self.lua('config.set', 0, 'jobs-history', 100)
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0, 'tags', ['foo'])
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0, 'tags', ['foo'])
         self.lua('pop', 0, 'queue', 'worker', 10)
         self.lua('complete', 0, 'jid', 'worker', 'queue', {})
         self.assertEqual(
             self.lua('tag', 99, 'get', 'foo', 0, 10)['jobs'], ['jid'])
         # We now need another job to complete to expire this job
-        self.lua('put', 101, 'queue', 'foo', 'klass', {}, 0)
+        self.lua('put', 101, 'worker', 'queue', 'foo', 'klass', {}, 0)
         self.lua('pop', 101, 'queue', 'worker', 10)
         self.lua('complete', 101, 'foo', 'worker', 'queue', {})
         self.assertEqual(
@@ -117,13 +117,13 @@ class TestTag(TestQless):
     def test_expired_count_jobs(self):
         '''When a job expires from jobs-history-count, remove from its tags'''
         self.lua('config.set', 0, 'jobs-history-count', 1)
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0, 'tags', ['foo'])
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0, 'tags', ['foo'])
         self.lua('pop', 0, 'queue', 'worker', 10)
         self.lua('complete', 0, 'jid', 'worker', 'queue', {})
         self.assertEqual(
             self.lua('tag', 0, 'get', 'foo', 0, 10)['jobs'], ['jid'])
         # We now need another job to complete to expire this job
-        self.lua('put', 1, 'queue', 'foo', 'klass', {}, 0)
+        self.lua('put', 1, 'worker', 'queue', 'foo', 'klass', {}, 0)
         self.lua('pop', 1, 'queue', 'worker', 10)
         self.lua('complete', 1, 'foo', 'worker', 'queue', {})
         self.assertEqual(
@@ -132,7 +132,7 @@ class TestTag(TestQless):
     def test_top(self):
         '''Ensure that we can find the most common tags'''
         for tag in range(10):
-            self.lua('put', 0, 'queue', tag, 'klass', {}, 0,
+            self.lua('put', 0, 'worker', 'queue', tag, 'klass', {}, 0,
                 'tags', range(tag, 10))
         self.assertEqual(self.lua('tag', 0, 'top', 0, 20),
             map(str, reversed(range(1, 10))))
@@ -149,7 +149,7 @@ class TestTag(TestQless):
         '''Pagination should work for tag.get'''
         jids = map(str, range(100))
         for jid in jids:
-            self.lua('put', jid, 'queue', jid, 'klass', {}, 0, 'tags', ['foo'])
+            self.lua('put', jid, 'worker', 'queue', jid, 'klass', {}, 0, 'tags', ['foo'])
         # Get two pages and ensure they're what we expect
         self.assertEqual(
             self.lua('tag', 100, 'get', 'foo',  0, 50)['jobs'], jids[:50])
@@ -161,7 +161,7 @@ class TestTag(TestQless):
         jids = map(str, range(10))
         for jid in jids:
             for suffix in map(str, range(int(jid) + 5)):
-                self.lua('put', jid, 'queue',
+                self.lua('put', jid, 'worker', 'queue',
                     jid + '.' + suffix, 'klass', {}, 0, 'tags', [jid])
         # Get two pages and ensure they're what we expect
         jids = list(reversed(jids))

--- a/test/test_track.py
+++ b/test/test_track.py
@@ -16,7 +16,7 @@ class TestTrack(TestQless):
 
     def test_track(self):
         '''Can track a job and it appears in "track"'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('track', 0, 'track', 'jid')
         self.assertEqual(self.lua('track', 0), {
             'jobs': [{
@@ -42,7 +42,7 @@ class TestTrack(TestQless):
 
     def test_untrack(self):
         '''We can stop tracking a job'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('track', 0, 'track', 'jid')
         self.lua('track', 0, 'untrack', 'jid')
         self.assertEqual(self.lua('track', 0), {'jobs': {}, 'expired': {}})
@@ -54,11 +54,11 @@ class TestTrack(TestQless):
 
     def test_jobs_tracked(self):
         '''Jobs know when they're tracked'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('track', 0, 'track', 'jid')
         self.assertEqual(self.lua('get', 0, 'jid')['tracked'], True)
 
     def test_jobs_untracked(self):
         '''Jobs know when they're not tracked'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.assertEqual(self.lua('get', 0, 'jid')['tracked'], False)

--- a/test/test_worker.py
+++ b/test/test_worker.py
@@ -12,7 +12,7 @@ class TestWorker(TestQless):
 
     def test_basic(self):
         '''Basic worker-level information'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('pop', 1, 'queue', 'worker', 10)
         self.assertEqual(self.lua('workers', 2, 'worker'), {
             'jobs': ['jid'],
@@ -26,7 +26,7 @@ class TestWorker(TestQless):
 
     def test_stalled(self):
         '''We should be able to detect stalled jobs'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         job = self.lua('pop', 1, 'queue', 'worker', 10)[0]
         expires = job['expires'] + 10
         self.lua('peek', expires, 'queue', 10)
@@ -42,7 +42,7 @@ class TestWorker(TestQless):
 
     def test_locks(self):
         '''When a lock is lost, removes the job from the worker's info'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         job = self.lua('pop', 1, 'queue', 'worker', 10)[0]
         self.assertEqual(self.lua('workers', 2, 'worker'), {
             'jobs': ['jid'],
@@ -59,7 +59,7 @@ class TestWorker(TestQless):
 
     def test_cancelled(self):
         '''Canceling a job removes it from the worker's stats'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('pop', 1, 'queue', 'worker', 10)
         self.assertEqual(self.lua('workers', 2, 'worker'), {
             'jobs': ['jid'],
@@ -79,7 +79,7 @@ class TestWorker(TestQless):
 
     def test_failed(self):
         '''When a job fails, it should be removed from a worker's jobs'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('pop', 1, 'queue', 'worker', 10)
         self.assertEqual(self.lua('workers', 2, 'worker'), {
             'jobs': ['jid'],
@@ -98,7 +98,7 @@ class TestWorker(TestQless):
 
     def test_complete(self):
         '''When a job completes, it should be remove from the worker's jobs'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('pop', 1, 'queue', 'worker', 10)
         self.assertEqual(self.lua('workers', 2, 'worker'), {
             'jobs': ['jid'],
@@ -117,13 +117,13 @@ class TestWorker(TestQless):
 
     def test_put(self):
         '''When a job's put in another queue, remove it from the worker'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('pop', 1, 'queue', 'worker', 10)
         self.assertEqual(self.lua('workers', 2, 'worker'), {
             'jobs': ['jid'],
             'stalled': {}
         })
-        self.lua('put', 3, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 3, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.assertEqual(self.lua('workers', 4, 'worker'), {
             'jobs': {},
             'stalled': {}
@@ -137,7 +137,7 @@ class TestWorker(TestQless):
     def test_reregister(self):
         '''We should be able to remove workers from the list of workers'''
         for jid in xrange(10):
-            self.lua('put', 0, 'queue', jid, 'klass', {}, 0)
+            self.lua('put', 0, 'worker', 'queue', jid, 'klass', {}, 0)
         # And pop them from 10 different workers
         workers = map(str, range(10))
         for worker in workers:
@@ -155,7 +155,7 @@ class TestWorker(TestQless):
         '''After a certain amount of time, inactive workers expire'''
         # Set the maximum worker age
         self.lua('config.set', 0, 'max-worker-age', 3600)
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('pop', 0, 'queue', 'worker', 10)
         self.lua('complete', 0, 'jid', 'worker', 'queue', {})
         # When we check on workers in a little while, it won't be listed
@@ -170,7 +170,7 @@ class TestWorker(TestQless):
 
     def test_retry_worker(self):
         '''When retried, it removes a job from the worker's data'''
-        self.lua('put', 0, 'queue', 'jid', 'klass', {}, 0)
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)
         self.lua('pop', 0, 'queue', 'worker', 10)
         self.lua(
             'retry', 0, 'jid', 'queue', 'worker', 0)


### PR DESCRIPTION
This was so that we could detect the case where a worker that owns a job is the one
that's invoking the 'put'. In that case, we'd like to avoid sending the lock lost
message since presumably it knows that it has moved the job.
