### PR TITLE
add pagination to worker counts, preserves backwards compatibility

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -74,8 +74,8 @@ QlessAPI.heartbeat = function(now, jid, worker, data)
   return Qless.job(jid):heartbeat(now, worker, data)
 end
 
-QlessAPI.workers = function(now, worker)
-  return cjson.encode(QlessWorker.counts(now, worker))
+QlessAPI.workers = function(now, ...)
+  return cjson.encode(QlessWorker.counts(now, unpack(arg)))
 end
 
 QlessAPI.track = function(now, command, jid)


### PR DESCRIPTION
With any significant number of workers (we have 1300, soon to be 8K+), workers.counts becomes unwieldy, especially in the qless ruby client's webui.

I tried to preserve backwards compatibility, so workers.counts without any args returns the entire set like it did before.

I also tried to match existing signatures that have pagination (e.g. offset, count as arguments).

However, as a result of the above two requirements (?) the QlessWorker.counts argument processing is a little hokey - basically I check wether the first arg is a number to determine wether the user intended to paginate all or get a single worker.
