### PR TITLE
fix memory leak on tags

### DIFF
--- a/job.lua
+++ b/job.lua
@@ -56,11 +56,11 @@ end
 
 -- Complete a job and optionally put it in another queue, either scheduled or
 -- to be considered waiting immediately. It can also optionally accept other
--- jids on which this job will be considered dependent before it's considered 
+-- jids on which this job will be considered dependent before it's considered
 -- valid.
 --
 -- The variable-length arguments may be pairs of the form:
--- 
+--
 --      ('next'   , queue) : The queue to advance it to next
 --      ('delay'  , delay) : The delay for the next queue
 --      ('depends',        : Json of jobs it depends on in the new queue
@@ -75,7 +75,7 @@ function QlessJob:complete(now, worker, queue, data, ...)
   -- Read in all the optional parameters
   local options = {}
   for i = 1, #arg, 2 do options[arg[i]] = arg[i + 1] end
-  
+
   -- Sanity check on optional args
   local nextq   = options['next']
   local delay   = assert(tonumber(options['delay'] or 0))
@@ -168,7 +168,7 @@ function QlessJob:complete(now, worker, queue, data, ...)
     if redis.call('zscore', 'ql:queues', nextq) == false then
       redis.call('zadd', 'ql:queues', now, nextq)
     end
-    
+
     redis.call('hmset', QlessJob.ns .. self.jid,
       'state', 'waiting',
       'worker', '',
@@ -176,7 +176,7 @@ function QlessJob:complete(now, worker, queue, data, ...)
       'queue', nextq,
       'expires', 0,
       'remaining', tonumber(retries))
-    
+
     if (delay > 0) and (#depends == 0) then
       queue_obj.scheduled.add(now + delay, self.jid)
       return 'scheduled'
@@ -224,48 +224,34 @@ function QlessJob:complete(now, worker, queue, data, ...)
       'queue', '',
       'expires', 0,
       'remaining', tonumber(retries))
-    
+
     -- Do the completion dance
     local count = Qless.config.get('jobs-history-count')
     local time  = Qless.config.get('jobs-history')
-    
+
     -- These are the default values
     count = tonumber(count or 50000)
     time  = tonumber(time  or 7 * 24 * 60 * 60)
-    
+
     -- Schedule this job for destructination eventually
     redis.call('zadd', 'ql:completed', now, self.jid)
-    
+
     -- Now look at the expired job data. First, based on the current time
     local jids = redis.call('zrangebyscore', 'ql:completed', 0, now - time)
     -- Any jobs that need to be expired... delete
     for index, jid in ipairs(jids) do
-      local tags = cjson.decode(
-        redis.call('hget', QlessJob.ns .. jid, 'tags') or '{}')
-      for i, tag in ipairs(tags) do
-        redis.call('zrem', 'ql:t:' .. tag, jid)
-        redis.call('zincrby', 'ql:tags', -1, tag)
-      end
-      redis.call('del', QlessJob.ns .. jid)
-      redis.call('del', QlessJob.ns .. jid .. '-history')
+      Qless.job(jid):delete()
     end
     -- And now remove those from the queued-for-cleanup queue
     redis.call('zremrangebyscore', 'ql:completed', 0, now - time)
-    
+
     -- Now take the all by the most recent 'count' ids
     jids = redis.call('zrange', 'ql:completed', 0, (-1-count))
     for index, jid in ipairs(jids) do
-      local tags = cjson.decode(
-        redis.call('hget', QlessJob.ns .. jid, 'tags') or '{}')
-      for i, tag in ipairs(tags) do
-        redis.call('zrem', 'ql:t:' .. tag, jid)
-        redis.call('zincrby', 'ql:tags', -1, tag)
-      end
-      redis.call('del', QlessJob.ns .. jid)
-      redis.call('del', QlessJob.ns .. jid .. '-history')
+      Qless.job(jid):delete()
     end
     redis.call('zremrangebyrank', 'ql:completed', 0, (-1-count))
-    
+
     -- Alright, if this has any dependents, then we should go ahead
     -- and unstick those guys.
     for i, j in ipairs(redis.call(
@@ -289,10 +275,10 @@ function QlessJob:complete(now, worker, queue, data, ...)
         end
       end
     end
-    
+
     -- Delete our dependents key
     redis.call('del', QlessJob.ns .. self.jid .. '-dependents')
-    
+
     return 'complete'
   end
 end
@@ -303,14 +289,14 @@ end
 -- specific message. By `group`, we mean some phrase that might be one of
 -- several categorical modes of failure. The `message` is something more
 -- job-specific, like perhaps a traceback.
--- 
+--
 -- This method should __not__ be used to note that a job has been dropped or
 -- has failed in a transient way. This method __should__ be used to note that
 -- a job has something really wrong with it that must be remedied.
--- 
+--
 -- The motivation behind the `group` is so that similar errors can be grouped
 -- together. Optionally, updated data can be provided for the job. A job in
--- any state can be marked as failed. If it has been given to a worker as a 
+-- any state can be marked as failed. If it has been given to a worker as a
 -- job, then its subsequent requests to heartbeat or complete that job will
 -- fail. Failed jobs are kept until they are canceled or completed.
 --
@@ -381,7 +367,7 @@ function QlessJob:fail(now, worker, group, message, data)
   queue_obj.locks.remove(self.jid)
   queue_obj.scheduled.remove(self.jid)
 
-  -- The reason that this appears here is that the above will fail if the 
+  -- The reason that this appears here is that the above will fail if the
   -- job doesn't exist
   if data then
     redis.call('hset', QlessJob.ns .. self.jid, 'data', cjson.encode(data))
@@ -418,7 +404,7 @@ end
 -- Throws an exception if:
 --      - the worker is not the worker with a lock on the job
 --      - the job is not actually running
--- 
+--
 -- Otherwise, it returns the number of retries remaining. If the allowed
 -- retries have been exhausted, then it is automatically failed, and a negative
 -- number is returned.
@@ -431,7 +417,7 @@ function QlessJob:retry(now, queue, worker, delay, group, message)
   assert(worker, 'Retry(): Arg "worker" missing')
   delay = assert(tonumber(delay or 0),
     'Retry(): Arg "delay" not a number: ' .. tostring(delay))
-  
+
   -- Let's see what the old priority, and tags were
   local oldqueue, state, retries, oldworker, priority, failure = unpack(
     redis.call('hmget', QlessJob.ns .. self.jid, 'queue', 'state',
@@ -464,7 +450,7 @@ function QlessJob:retry(now, queue, worker, delay, group, message)
     -- queue it's in
     local group = group or 'failed-retries-' .. queue
     self:history(now, 'failed', {['group'] = group})
-    
+
     redis.call('hmset', QlessJob.ns .. self.jid, 'state', 'failed',
       'worker', '',
       'expires', '')
@@ -488,7 +474,7 @@ function QlessJob:retry(now, queue, worker, delay, group, message)
         ['worker']  = unpack(self:data('worker'))
       }))
     end
-    
+
     -- Add this type of failure to the list of failures
     redis.call('sadd', 'ql:failures', group)
     -- And add this particular instance to the failed types
@@ -640,11 +626,11 @@ function QlessJob:heartbeat(now, worker, data)
       redis.call('hmset', QlessJob.ns .. self.jid,
         'expires', expires, 'worker', worker)
     end
-    
+
     -- Update hwen this job was last updated on that worker
     -- Add this job to the list of jobs handled by this worker
     redis.call('zadd', 'ql:w:' .. worker .. ':jobs', expires, self.jid)
-    
+
     -- And now we should just update the locks
     local queue = Qless.queue(
       redis.call('hget', QlessJob.ns .. self.jid, 'queue'))
@@ -788,5 +774,49 @@ function QlessJob:history(now, what, item)
     end
     return redis.call('rpush', QlessJob.ns .. self.jid .. '-history',
       cjson.encode({math.floor(now), what, item}))
+  end
+end
+
+-- Completely removes all the data
+-- associated with this job, use
+-- with care.
+function QlessJob:delete()
+  local tags = redis.call('hget', QlessJob.ns .. self.jid, 'tags') or '[]'
+  tags = cjson.decode(tags)
+  -- remove the jid from each tag
+  for i, tag in ipairs(tags) do
+    self:remove_tag(tag)
+  end
+  -- Delete the job's data
+  redis.call('del', QlessJob.ns .. self.jid)
+  -- Delete the job's history
+  redis.call('del', QlessJob.ns .. self.jid .. '-history')
+  -- Delete any notion of dependencies it has
+  redis.call('del', QlessJob.ns .. self.jid .. '-dependencies')
+end
+
+-- Inserts the jid into the specified tag.
+-- This should probably be moved to its own tag
+-- object.
+function QlessJob:insert_tag(now, tag)
+  redis.call('zadd', 'ql:t:' .. tag, now, self.jid)
+  redis.call('zincrby', 'ql:tags', 1, tag)
+end
+
+-- Removes the jid from the specified tag.
+-- this should probably be moved to its own tag
+-- object.
+function QlessJob:remove_tag(tag)
+  -- Remove the job from the specified tag
+  redis.call('zrem', 'ql:t:' .. tag, self.jid)
+
+  -- Decrement the tag in the set of all tags.
+  local score = redis.call('zincrby', 'ql:tags', -1, tag)
+
+  -- if the score for the specified tag is 0
+  -- it means we have no jobs with this tag anymore
+  -- and we should remove it from the set to prevent memory leaks.
+  if tonumber(score) == 0 then
+    redis.call('zrem', 'ql:tags', tag)
   end
 end

--- a/test/common.py
+++ b/test/common.py
@@ -12,7 +12,8 @@ class TestQless(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         url = os.environ.get('REDIS_URL', 'redis://localhost:6379/')
-        cls.lua = qless.QlessRecorder(redis.Redis.from_url(url))
+        cls.redis = redis.Redis.from_url(url)
+        cls.lua = qless.QlessRecorder(cls.redis)
 
     def tearDown(self):
         self.lua.flush()

--- a/test/test_job.py
+++ b/test/test_job.py
@@ -183,6 +183,23 @@ class TestComplete(TestQless):
         existing = [self.lua('get', 3, jid) for jid in range(10)]
         self.assertEqual([i for i in existing if i], [])
 
+    def test_expire_complete_tags_cleared(self):
+        '''Tag's should be removed once they no longer have any jobs'''
+        # Set all jobs to expire immediately
+        self.lua('config.set', 1, 'jobs-history', -1)
+        # When cancelled
+        self.lua('put', 2, 'worker', 'queue', 'jid', 'klass', {}, 0, 'tags', ['abc'])
+        self.assertEqual(self.lua('tag', 3, 'get', 'abc', 0, 0)['jobs'], ['jid'])
+        self.lua('cancel', 4, 'jid', 'worker', 'queue', {})
+        self.assertEqual(self.lua('tag', 5, 'get', 'abc', 0, 0)['jobs'], {})
+        self.assertEqual(self.redis.zrange('ql:tags', 0, -1), [])
+        # When complete
+        self.lua('put', 6, 'worker', 'queue', 'jid', 'klass', {}, 0, 'tags', ['abc'])
+        self.assertEqual(self.lua('tag', 7, 'get', 'abc', 0, 0)['jobs'], ['jid'])
+        self.lua('pop', 8, 'queue', 'worker', 1)
+        self.lua('complete', 9, 'jid', 'worker', 'queue', {})
+        self.assertEqual(self.lua('tag', 10, 'get', 'abc', 0, 0)['jobs'], {})
+        self.assertEqual(self.redis.zrange('ql:tags', 0, -1), [])
 
 class TestCancel(TestQless):
     '''Canceling jobs'''


### PR DESCRIPTION
the ql:tags set continues to grow even if the tag is no longer used by any jobs.

this PR addresses that.
