### PR TITLE
Add requeue.

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -148,6 +148,12 @@ QlessAPI.put = function(now, me, queue, jid, klass, data, delay, ...)
   return Qless.queue(queue):put(now, me, jid, klass, data, delay, unpack(arg))
 end
 
+QlessAPI.requeue = function(now, me, queue, jid, ...)
+  local job = Qless.job(jid)
+  assert(job:exists(), 'Requeue(): Job ' .. jid .. ' does not exist')
+  return QlessAPI.put(now, me, queue, jid, unpack(arg))
+end
+
 QlessAPI.unfail = function(now, queue, group, count)
   return Qless.queue(queue):unfail(now, group, count)
 end


### PR DESCRIPTION
This is useful when you want to put a job back on a queue
(e.g. to have it tried again later) without worrying about
potentially resurrecting a cancelled job.

@dlecocq -- we talked about this being `move` but I realized that there's no requirement that a different queue be provided and in our use case we are simply putting the job back on the same queue, so @benkirzhner  and I felt like it made more sense to call it `requeue` (it can obviously be used to move the job as well).
