### PR TITLE
Fix job data mangling on advance

### DIFF
--- a/job.lua
+++ b/job.lua
@@ -66,11 +66,11 @@ end
 --      ('depends',        : Json of jobs it depends on in the new queue
 --          '["jid1", "jid2", ...]')
 ---
-function QlessJob:complete(now, worker, queue, data, ...)
+function QlessJob:complete(now, worker, queue, raw_data, ...)
   assert(worker, 'Complete(): Arg "worker" missing')
   assert(queue , 'Complete(): Arg "queue" missing')
-  data = assert(cjson.decode(data),
-    'Complete(): Arg "data" missing or not JSON: ' .. tostring(data))
+  local data = assert(cjson.decode(raw_data),
+    'Complete(): Arg "data" missing or not JSON: ' .. tostring(raw_data))
 
   -- Read in all the optional parameters
   local options = {}
@@ -121,8 +121,8 @@ function QlessJob:complete(now, worker, queue, data, ...)
   --          update history
   self:history(now, 'done')
 
-  if data then
-    redis.call('hset', QlessJob.ns .. self.jid, 'data', cjson.encode(data))
+  if raw_data then
+    redis.call('hset', QlessJob.ns .. self.jid, 'data', raw_data)
   end
 
   -- Remove the job from the previous queue

--- a/test/test_job.py
+++ b/test/test_job.py
@@ -158,6 +158,14 @@ class TestComplete(TestQless):
         self.assertEqual(
             self.lua('pop', 3, 'foo', 'worker', 10)[0]['jid'], 'jid')
 
+    def test_advance_empty_array_mangle(self):
+        '''Does not mangle empty arrays in job data when advancing'''
+        self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', '[]', 0)
+        self.lua('pop', 1, 'queue', 'worker', 10)
+        self.lua('complete', 2, 'jid', 'worker', 'queue', '[]', 'next', 'foo')
+        self.assertEqual(
+            self.lua('pop', 3, 'foo', 'worker', 10)[0]['data'], '[]')
+
     def test_wrong_worker(self):
         '''Only the right worker can complete it'''
         self.lua('put', 0, 'worker', 'queue', 'jid', 'klass', {}, 0)


### PR DESCRIPTION
Similar to https://github.com/seomoz/qless-core/pull/6 except for completeJob.
Empty arrays in job data are coming back out as empty objects when advancing a job.

