### PR TITLE
Build against multiple redis versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,7 @@ install:
 env:
   - REDIS_VERSION=3.0.7
   - REDIS_VERSION=3.2.8
+matrix:
+  allow_failures:
+    - env: REDIS_VERSION=3.2.8
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 sudo: false
-services:
-  - redis-server
 language: python
 python:
   - 2.6
   - 2.7
   - pypy
 install:
+  - make build-redis
+  - make run-redis &
   - pip install redis --use-mirrors
-script:  make test
+env:
+  - REDIS_VERSION=3.0.7
+  - REDIS_VERSION=3.2.8
+script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ python:
   - 2.7
   - pypy
 install:
-  - make build-redis
-  - make run-redis &
+  - make redis
   - pip install redis --use-mirrors
 env:
   - REDIS_VERSION=3.0.7

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,28 @@ qless.lua: qless-lib.lua api.lua
 		egrep -v '^[[:space:]]*--[^\[]' | \
 		egrep -v '^--$$' >> qless.lua
 
-clean:
-	rm -f qless.lua qless-lib.lua
+REDIS_VERSION ?= stable
+REDIS_DIR = redis-$(REDIS_VERSION)
+REDIS_TAR = redis-$(REDIS_VERSION).tar.gz
+REDIS_BIN = $(REDIS_DIR)/src/redis-server
 
-.PHONY: test
+.PHONY: clean test redis
+clean:
+	rm -rf qless.lua qless-lib.lua $(REDIS_TAR) $(REDIS_DIR)
+
 test: qless.lua *.lua
 	nosetests --exe -v
+
+$(REDIS_TAR):
+	curl -O http://download.redis.io/releases/$(REDIS_TAR)
+
+$(REDIS_DIR): $(REDIS_TAR)
+	tar xvf $(REDIS_TAR)
+
+$(REDIS_BIN): $(REDIS_DIR)
+	cd $(REDIS_DIR) && make
+
+build-redis: $(REDIS_BIN)
+
+run-redis: $(REDIS_BIN)
+	$(REDIS_BIN) --daemonize yes

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,5 @@ $(REDIS_DIR): $(REDIS_TAR)
 $(REDIS_BIN): $(REDIS_DIR)
 	cd $(REDIS_DIR) && make
 
-build-redis: $(REDIS_BIN)
-
-run-redis: $(REDIS_BIN)
+redis: $(REDIS_BIN)
 	$(REDIS_BIN) --daemonize yes


### PR DESCRIPTION
This way, we can better address problems like #64 that are specific to certain redis versions. Once this is merged, we can rebase #64 on top of it and confirm that it fixes the issue before merging.