### PR TITLE
Stop allowing build failures for redis 3.2.8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,4 @@ install:
 env:
   - REDIS_VERSION=3.0.7
   - REDIS_VERSION=3.2.8
-matrix:
-  allow_failures:
-    - env: REDIS_VERSION=3.2.8
 script: make test


### PR DESCRIPTION
Now that builds for redis 3.2.8 are made green by #64, we can stop ignoring their failures.