### PR TITLE
Add .npmignore to support qless-js

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+*.pyc
+*~
+.vagrant


### PR DESCRIPTION
The npm packaging rules are such that if a .gitignore is
present, but a .npmignore is not, all the rules outlined
in .gitignore are used when selecting files for package
time. Despite this package being a submodule for qless-js,
that policy appears to be honored at this level as well.
Since npm needs to package up the generated files
(qless.lua and qless-lib.lua), we provide a .npmignore
that explicitly does not ignore those files.

@benkirzhner @evanbattaglia 