### PR TITLE
Drop pypy from test matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: python
 python:
   - 2.7
-  - pypy
 install:
   - make redis
   - pip install redis


### PR DESCRIPTION
We don't need to test python version support; qless-py can test that.

Right now, this just needlessly slows the Travis build.