### PR TITLE
Support waiting job pagination

### DIFF
--- a/base.lua
+++ b/base.lua
@@ -146,6 +146,8 @@ function Qless.jobs(now, state, ...)
       return queue.locks.peek(now, offset, count)
     elseif state == 'stalled' then
       return queue.locks.expired(now, offset, count)
+    elseif state == 'waiting' then
+      return queue.work.peek(now, offset, count)
     elseif state == 'scheduled' then
       queue:check_scheduled(now, queue.scheduled.length())
       return queue.scheduled.peek(now, offset, count)

--- a/queue.lua
+++ b/queue.lua
@@ -10,13 +10,13 @@ function Qless.queue(name)
 
   -- Access to our work
   queue.work = {
-    peek = function(count)
+    peek = function(now, offset, count)
       if count == 0 then
         return {}
       end
       local jids = {}
       for index, jid in ipairs(redis.call(
-        'zrevrange', queue:prefix('work'), 0, count - 1)) do
+        'zrevrange', queue:prefix('work'), offset, offset + count - 1)) do
         table.insert(jids, jid)
       end
       return jids
@@ -247,7 +247,7 @@ function QlessQueue:peek(now, count)
 
   -- With these in place, we can expand this list of jids based on the work
   -- queue itself and the priorities therein
-  table.extend(jids, self.work.peek(count - #jids))
+  table.extend(jids, self.work.peek(now, 0, count - #jids))
 
   return jids
 end
@@ -322,7 +322,7 @@ function QlessQueue:pop(now, worker, count)
 
   -- With these in place, we can expand this list of jids based on the work
   -- queue itself and the priorities therein
-  table.extend(jids, self.work.peek(count - #jids))
+  table.extend(jids, self.work.peek(now, 0, count - #jids))
 
   local state
   for index, jid in ipairs(jids) do

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -132,6 +132,17 @@ class TestJobs(TestQless):
         self.assertEqual(
             self.lua('jobs', 100, 'running', 'queue', 50, 50), jids[50:])
 
+    def test_pagination_waiting(self):
+        '''Jobs should be able to provide paginated result for waiting'''
+        jids = map(str, range(100))
+        for jid in jids:
+            self.lua('put', jid, 'worker', 'queue', jid, 'klass', {}, 0)
+        # Get two pages and ensure they're what we expect
+        self.assertEqual(
+            self.lua('jobs', 100, 'waiting', 'queue',  0, 50), jids[:50])
+        self.assertEqual(
+            self.lua('jobs', 100, 'waiting', 'queue', 50, 50), jids[50:])
+
 
 class TestQueue(TestQless):
     '''Test queue info tests'''


### PR DESCRIPTION
I have a scenario where I need to iterate through all waiting jobs in a queue so I can cancel them, but was surprised to find this feature missing. This simple PR adds support for the "waiting" status in the existing pageable `jobs` API.

Unit test included of course.