### PR TITLE
Convert method table.extend() to a local function because 'table' is …

### DIFF
--- a/base.lua
+++ b/base.lua
@@ -31,9 +31,9 @@ QlessRecurringJob.__index = QlessRecurringJob
 Qless.config = {}
 
 -- Extend a table. This comes up quite frequently
-function table.extend(self, other)
+local function extend_table(target, other)
   for i, v in ipairs(other) do
-    table.insert(self, v)
+    table.insert(target, v)
   end
 end
 

--- a/queue.lua
+++ b/queue.lua
@@ -247,7 +247,7 @@ function QlessQueue:peek(now, count)
 
   -- With these in place, we can expand this list of jids based on the work
   -- queue itself and the priorities therein
-  table.extend(jids, self.work.peek(count - #jids))
+  extend_table(jids, self.work.peek(count - #jids))
 
   return jids
 end
@@ -322,7 +322,7 @@ function QlessQueue:pop(now, worker, count)
 
   -- With these in place, we can expand this list of jids based on the work
   -- queue itself and the priorities therein
-  table.extend(jids, self.work.peek(count - #jids))
+  extend_table(jids, self.work.peek(count - #jids))
 
   local state
   for index, jid in ipairs(jids) do


### PR DESCRIPTION
…readonly since Redis 6.2.7

See https://github.com/redis/redis/pull/10651.

Fixes #89.

Reported-by: Anton Baklanov (@bak1an)