### PR TITLE
Sort 'dependents' and 'dependencies' before comparing them to fix a f…

### DIFF
--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -62,8 +62,8 @@ class TestDependencies(TestQless):
             'depends', ['a'], 'next', 'queue')
         # Ensure that it shows up everywhere it should
         self.assertEqual(self.lua('get', 4, 'b')['state'], 'depends')
-        self.assertEqual(self.lua('get', 5, 'b')['dependencies'], ['a'])
-        self.assertEqual(self.lua('get', 6, 'a')['dependents'], ['b'])
+        self.assertEqual(sorted(self.lua('get', 5, 'b')['dependencies']), ['a'])
+        self.assertEqual(sorted(self.lua('get', 6, 'a')['dependents']), ['b'])
         # Only one job should be available
         self.assertEqual(len(self.lua('peek', 7, 'queue', 10)), 1)
 
@@ -154,7 +154,7 @@ class TestDependencies(TestQless):
         self.lua('put', 1, 'worker', 'queue', 'b', 'klass', {}, 0)
         self.lua('put', 2, 'worker', 'queue', 'c', 'klass', {}, 0, 'depends', ['a'])
         self.lua('depends', 3, 'c', 'on', 'b')
-        self.assertEqual(self.lua('get', 4, 'c')['dependencies'], ['a', 'b'])
+        self.assertEqual(sorted(self.lua('get', 4, 'c')['dependencies']), ['a', 'b'])
 
     def test_remove_dependency(self):
         '''We can remove dependencies'''
@@ -176,9 +176,9 @@ class TestDependencies(TestQless):
         self.lua('put', 1, 'worker', 'queue', 'b', 'klass', {}, 0)
         self.lua('put', 2, 'worker', 'queue', 'c', 'klass', {}, 0, 'depends', ['a'])
         self.lua('put', 3, 'worker', 'queue', 'c', 'klass', {}, 0, 'depends', ['b'])
-        self.assertEqual(self.lua('get', 4, 'c')['dependencies'], ['b'])
+        self.assertEqual(sorted(self.lua('get', 4, 'c')['dependencies']), ['b'])
         self.assertEqual(self.lua('get', 5, 'a')['dependents'], {})
-        self.assertEqual(self.lua('get', 6, 'b')['dependents'], ['c'])
+        self.assertEqual(sorted(self.lua('get', 6, 'b')['dependents']), ['c'])
         # Also, let's make sure that its effective dependencies are changed
         self.lua('pop', 7, 'queue', 'worker', 10)
         self.lua('complete', 8, 'a', 'worker', 'queue', {})

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -362,16 +362,16 @@ class TestPut(TestQless):
         '''Dependencies are reflected in job data'''
         self.lua('put', 12345, 'worker', 'queue', 'a', 'klass', {}, 0)
         self.lua('put', 12345, 'worker', 'queue', 'b', 'klass', {}, 0, 'depends', ['a'])
-        self.assertEqual(self.lua('get', 12345, 'a')['dependents'], ['b'])
-        self.assertEqual(self.lua('get', 12345, 'b')['dependencies'], ['a'])
+        self.assertEqual(sorted(self.lua('get', 12345, 'a')['dependents']), ['b'])
+        self.assertEqual(sorted(self.lua('get', 12345, 'b')['dependencies']), ['a'])
         self.assertEqual(self.lua('get', 12345, 'b')['state'], 'depends')
 
     def test_put_depends_with_delay(self):
         '''When we put a job with a depends and a delay it is reflected in the job data'''
         self.lua('put', 12345, 'worker', 'queue', 'a', 'klass', {}, 0)
         self.lua('put', 12345, 'worker', 'queue', 'b', 'klass', {}, 1, 'depends', ['a'])
-        self.assertEqual(self.lua('get', 12345, 'a')['dependents'], ['b'])
-        self.assertEqual(self.lua('get', 12345, 'b')['dependencies'], ['a'])
+        self.assertEqual(sorted(self.lua('get', 12345, 'a')['dependents']), ['b'])
+        self.assertEqual(sorted(self.lua('get', 12345, 'b')['dependencies']), ['a'])
         self.assertEqual(self.lua('get', 12345, 'b')['state'], 'depends')
 
     def test_move(self):
@@ -420,14 +420,14 @@ class TestPut(TestQless):
         self.lua('put', 0, 'worker', 'queue', 'b', 'klass', {}, 0)
         self.lua('put', 0, 'worker', 'queue', 'c', 'klass', {}, 0, 'depends', ['a'])
         self.lua('put', 0, 'worker', 'other', 'c', 'klass', {}, 0)
-        self.assertEqual(self.lua('get', 0, 'a')['dependents'], ['c'])
+        self.assertEqual(sorted(self.lua('get', 0, 'a')['dependents']), ['c'])
         self.assertEqual(self.lua('get', 0, 'b')['dependents'], {})
-        self.assertEqual(self.lua('get', 0, 'c')['dependencies'], ['a'])
+        self.assertEqual(sorted(self.lua('get', 0, 'c')['dependencies']), ['a'])
         # But if we move and update depends, then it should correctly reflect
         self.lua('put', 0, 'worker', 'queue', 'c', 'klass', {}, 0, 'depends', ['b'])
         self.assertEqual(self.lua('get', 0, 'a')['dependents'], {})
-        self.assertEqual(self.lua('get', 0, 'b')['dependents'], ['c'])
-        self.assertEqual(self.lua('get', 0, 'c')['dependencies'], ['b'])
+        self.assertEqual(sorted(self.lua('get', 0, 'b')['dependents']), ['c'])
+        self.assertEqual(sorted(self.lua('get', 0, 'c')['dependencies']), ['b'])
 
 
 class TestPeek(TestQless):


### PR DESCRIPTION
…ailing test on Redis 6.2.7

Redis sets are unordered. In Redis 4.0 the Lua API silently sorted
sets before returning them, but since Redis 5.0 the sorting is no
longer performed.\[1]

One of the tests broke on Redis 6.2.7 because the order changed. Sort
the lists before comparing them to fix this.

(It's only strictly necessary to sort when there are 2+ elements, but
for consistency this commit also sorts when there is just 1 element.
Empty sets are special because an empty Lua table is converted to a
Python dict rather than a list; this commit does not sort empty sets
to avoid masking this idiosyncrasy.)

\[1]: https://redis.io/docs/manual/programmability/eval-intro/