### PR TITLE
Adding Redis 5.0.6 support to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ env:
   - REDIS_VERSION=3.0.7
   - REDIS_VERSION=3.2.11
   - REDIS_VERSION=4.0.6
+  - REDIS_VERSION=5.0.6
 script: make test

--- a/provision.sh
+++ b/provision.sh
@@ -23,7 +23,7 @@ sudo apt-get install -y libhiredis-dev libevent-dev python-pip python-dev
 
     # Download and install the thing
     cd /tmp
-    export REDIS_VERSION=4.0.6
+    export REDIS_VERSION=5.0.6
     wget http://download.redis.io/releases/redis-$REDIS_VERSION.tar.gz
     tar xf redis-$REDIS_VERSION.tar.gz
     (

--- a/provision/etc/redis.conf
+++ b/provision/etc/redis.conf
@@ -87,7 +87,7 @@ timeout 0
 # On other kernels the period depends on the kernel configuration.
 #
 # A reasonable value for this option is 60 seconds.
-tcp-keepalive 0
+tcp-keepalive 60
 
 # Specify the server verbosity level.
 # This can be one of:
@@ -550,7 +550,7 @@ appendfsync everysec
 # If you have latency problems turn this to "yes". Otherwise leave it as
 # "no" that is the safest pick from the point of view of durability.
 
-no-appendfsync-on-rewrite no
+no-appendfsync-on-rewrite no #tcg
 
 # Automatic rewrite of the append only file.
 # Redis is able to automatically rewrite the log file implicitly calling


### PR DESCRIPTION
Testing Qless, currently facing problem with  Upgraded AWS ElastiCache Cluster.(5.0.6).