### PR TITLE
Updating to work with Redis 6.0

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -11,7 +11,7 @@ function QlessAPI.get(now, jid)
   if not data then
     return nil
   end
-  return cjson.encode(data)
+  return json_encode(data)
 end
 
 -- Return json blob of data or nil for each jid provided
@@ -20,13 +20,13 @@ function QlessAPI.multiget(now, ...)
   for i, jid in ipairs(arg) do
     table.insert(results, Qless.job(jid):data())
   end
-  return cjson.encode(results)
+  return json_encode(results)
 end
 
 -- Public access
 QlessAPI['config.get'] = function(now, key)
   if not key then
-    return cjson.encode(Qless.config.get(key))
+    return json_encode(Qless.config.get(key))
   else
     return Qless.config.get(key)
   end
@@ -43,7 +43,7 @@ end
 
 -- Get information about a queue or queues
 QlessAPI.queues = function(now, queue)
-  return cjson.encode(QlessQueue.counts(now, queue))
+  return json_encode(QlessQueue.counts(now, queue))
 end
 
 QlessAPI.complete = function(now, jid, worker, queue, data, ...)
@@ -51,7 +51,7 @@ QlessAPI.complete = function(now, jid, worker, queue, data, ...)
 end
 
 QlessAPI.failed = function(now, group, start, limit)
-  return cjson.encode(Qless.failed(group, start, limit))
+  return json_encode(Qless.failed(group, start, limit))
 end
 
 QlessAPI.fail = function(now, jid, worker, group, message, data)
@@ -75,19 +75,19 @@ QlessAPI.heartbeat = function(now, jid, worker, data)
 end
 
 QlessAPI.workers = function(now, worker)
-  return cjson.encode(QlessWorker.counts(now, worker))
+  return json_encode(QlessWorker.counts(now, worker))
 end
 
 QlessAPI.track = function(now, command, jid)
-  return cjson.encode(Qless.track(now, command, jid))
+  return json_encode(Qless.track(now, command, jid))
 end
 
 QlessAPI.tag = function(now, command, ...)
-  return cjson.encode(Qless.tag(now, command, unpack(arg)))
+  return json_encode(Qless.tag(now, command, unpack(arg)))
 end
 
 QlessAPI.stats = function(now, queue, date)
-  return cjson.encode(Qless.queue(queue):stats(now, date))
+  return json_encode(Qless.queue(queue):stats(now, date))
 end
 
 QlessAPI.priority = function(now, jid, priority)
@@ -99,7 +99,7 @@ QlessAPI.log = function(now, jid, message, data)
   assert(jid, "Log(): Argument 'jid' missing")
   assert(message, "Log(): Argument 'message' missing")
   if data then
-    data = assert(cjson.decode(data),
+    data = assert(json_decode(data),
       "Log(): Argument 'data' not cjson: " .. tostring(data))
   end
 
@@ -114,7 +114,7 @@ QlessAPI.peek = function(now, queue, count)
   for i, jid in ipairs(jids) do
     table.insert(response, Qless.job(jid):data())
   end
-  return cjson.encode(response)
+  return json_encode(response)
 end
 
 QlessAPI.pop = function(now, queue, worker, count)
@@ -123,7 +123,7 @@ QlessAPI.pop = function(now, queue, worker, count)
   for i, jid in ipairs(jids) do
     table.insert(response, Qless.job(jid):data())
   end
-  return cjson.encode(response)
+  return json_encode(response)
 end
 
 QlessAPI.pause = function(now, ...)
@@ -172,7 +172,7 @@ QlessAPI['recur.get'] = function(now, jid)
   if not data then
     return nil
   end
-  return cjson.encode(data)
+  return json_encode(data)
 end
 
 QlessAPI['recur.update'] = function(now, jid, ...)

--- a/base.lua
+++ b/base.lua
@@ -35,7 +35,7 @@ QlessRecurringJob.__index = QlessRecurringJob
 Qless.config = {}
 
 -- Extend a table. This comes up quite frequently
-function table.extend(self, other)
+local function table_extend(self, other)
   for i, v in ipairs(other) do
     table.insert(self, v)
   end

--- a/base.lua
+++ b/base.lua
@@ -1,6 +1,10 @@
 -------------------------------------------------------------------------------
 -- Forward declarations to make everything happy
 -------------------------------------------------------------------------------
+-- Define local aliases for cjson to satisfy Redis 6+ Lua sandbox
+local json_encode = cjson.encode
+local json_decode = cjson.decode
+
 local Qless = {
   ns = 'ql:'
 }

--- a/config.lua
+++ b/config.lua
@@ -33,7 +33,7 @@ Qless.config.set = function(option, value)
   assert(option, 'config.set(): Arg "option" missing')
   assert(value , 'config.set(): Arg "value" missing')
   -- Send out a log message
-  Qless.publish('log', cjson.encode({
+  Qless.publish('log', json_encode({
     event  = 'config_set',
     option = option,
     value  = value
@@ -46,7 +46,7 @@ end
 Qless.config.unset = function(option)
   assert(option, 'config.unset(): Arg "option" missing')
   -- Send out a log message
-  Qless.publish('log', cjson.encode({
+  Qless.publish('log', json_encode({
     event  = 'config_unset',
     option = option
   }))

--- a/job.lua
+++ b/job.lua
@@ -31,9 +31,9 @@ function QlessJob:data(...)
     retries          = tonumber(job[8]),
     remaining        = math.floor(tonumber(job[9])),
     data             = job[10],
-    tags             = cjson.decode(job[11]),
+    tags             = json_decode(job[11]),
     history          = self:history(),
-    failure          = cjson.decode(job[12] or '{}'),
+    failure          = json_decode(job[12] or '{}'),
     spawned_from_jid = job[13],
     dependents       = redis.call(
       'smembers', QlessJob.ns .. self.jid .. '-dependents'),
@@ -69,7 +69,7 @@ end
 function QlessJob:complete(now, worker, queue, raw_data, ...)
   assert(worker, 'Complete(): Arg "worker" missing')
   assert(queue , 'Complete(): Arg "queue" missing')
-  local data = assert(cjson.decode(raw_data),
+  local data = assert(json_decode(raw_data),
     'Complete(): Arg "data" missing or not JSON: ' .. tostring(raw_data))
 
   -- Read in all the optional parameters
@@ -79,7 +79,7 @@ function QlessJob:complete(now, worker, queue, raw_data, ...)
   -- Sanity check on optional args
   local nextq   = options['next']
   local delay   = assert(tonumber(options['delay'] or 0))
-  local depends = assert(cjson.decode(options['depends'] or '[]'),
+  local depends = assert(json_decode(options['depends'] or '[]'),
     'Complete(): Arg "depends" not JSON: ' .. tostring(options['depends']))
 
   -- Depends doesn't make sense without nextq
@@ -154,7 +154,7 @@ function QlessJob:complete(now, worker, queue, raw_data, ...)
   if nextq then
     queue_obj = Qless.queue(nextq)
     -- Send a message out to log
-    Qless.publish('log', cjson.encode({
+    Qless.publish('log', json_encode({
       jid   = self.jid,
       event = 'advanced',
       queue = queue,
@@ -212,7 +212,7 @@ function QlessJob:complete(now, worker, queue, raw_data, ...)
     end
   else
     -- Send a message out to log
-    Qless.publish('log', cjson.encode({
+    Qless.publish('log', json_encode({
       jid   = self.jid,
       event = 'completed',
       queue = queue
@@ -241,7 +241,7 @@ function QlessJob:complete(now, worker, queue, raw_data, ...)
     local jids = redis.call('zrangebyscore', 'ql:completed', 0, now - time)
     -- Any jobs that need to be expired... delete
     for index, jid in ipairs(jids) do
-      local tags = cjson.decode(
+      local tags = json_decode(
         redis.call('hget', QlessJob.ns .. jid, 'tags') or '{}')
       for i, tag in ipairs(tags) do
         redis.call('zrem', 'ql:t:' .. tag, jid)
@@ -256,7 +256,7 @@ function QlessJob:complete(now, worker, queue, raw_data, ...)
     -- Now take the all by the most recent 'count' ids
     jids = redis.call('zrange', 'ql:completed', 0, (-1-count))
     for index, jid in ipairs(jids) do
-      local tags = cjson.decode(
+      local tags = json_decode(
         redis.call('hget', QlessJob.ns .. jid, 'tags') or '{}')
       for i, tag in ipairs(tags) do
         redis.call('zrem', 'ql:t:' .. tag, jid)
@@ -334,7 +334,7 @@ function QlessJob:fail(now, worker, group, message, data)
   local bin = now - (now % 86400)
 
   if data then
-    data = cjson.decode(data)
+    data = json_decode(data)
   end
 
   -- First things first, we should get the history
@@ -352,7 +352,7 @@ function QlessJob:fail(now, worker, group, message, data)
   end
 
   -- Send out a log message
-  Qless.publish('log', cjson.encode({
+  Qless.publish('log', json_encode({
     jid     = self.jid,
     event   = 'failed',
     worker  = worker,
@@ -386,14 +386,14 @@ function QlessJob:fail(now, worker, group, message, data)
   -- The reason that this appears here is that the above will fail if the
   -- job doesn't exist
   if data then
-    redis.call('hset', QlessJob.ns .. self.jid, 'data', cjson.encode(data))
+    redis.call('hset', QlessJob.ns .. self.jid, 'data', json_encode(data))
   end
 
   redis.call('hmset', QlessJob.ns .. self.jid,
     'state', 'failed',
     'worker', '',
     'expires', '',
-    'failure', cjson.encode({
+    'failure', json_encode({
       ['group']   = group,
       ['message'] = message,
       ['when']    = math.floor(now),
@@ -475,7 +475,7 @@ function QlessJob:retry(now, queue, worker, delay, group, message)
     -- If the failure has not already been set, then set it
     if group ~= nil and message ~= nil then
       redis.call('hset', QlessJob.ns .. self.jid,
-        'failure', cjson.encode({
+        'failure', json_encode({
           ['group']   = group,
           ['message'] = message,
           ['when']    = math.floor(now),
@@ -484,7 +484,7 @@ function QlessJob:retry(now, queue, worker, delay, group, message)
       )
     else
       redis.call('hset', QlessJob.ns .. self.jid,
-      'failure', cjson.encode({
+      'failure', json_encode({
         ['group']   = group,
         ['message'] =
           'Job exhausted retries in queue "' .. oldqueue .. '"',
@@ -519,7 +519,7 @@ function QlessJob:retry(now, queue, worker, delay, group, message)
     -- If a group and a message was provided, then we should save it
     if group ~= nil and message ~= nil then
       redis.call('hset', QlessJob.ns .. self.jid,
-        'failure', cjson.encode({
+        'failure', json_encode({
           ['group']   = group,
           ['message'] = message,
           ['when']    = math.floor(now),
@@ -623,7 +623,7 @@ function QlessJob:heartbeat(now, worker, data)
     Qless.config.get('heartbeat', 60))
 
   if data then
-    data = cjson.decode(data)
+    data = json_decode(data)
   end
 
   -- First, let's see if the worker still owns this job, and there is a
@@ -646,7 +646,7 @@ function QlessJob:heartbeat(now, worker, data)
       -- I don't know if this is wise, but I'm decoding and encoding
       -- the user data to hopefully ensure its sanity
       redis.call('hmset', QlessJob.ns .. self.jid, 'expires',
-        expires, 'worker', worker, 'data', cjson.encode(data))
+        expires, 'worker', worker, 'data', json_encode(data))
     else
       redis.call('hmset', QlessJob.ns .. self.jid,
         'expires', expires, 'worker', worker)
@@ -724,7 +724,7 @@ function QlessJob:timeout(now)
     queue.work.add(now, '+inf', self.jid)
     redis.call('hmset', QlessJob.ns .. self.jid,
       'state', 'stalled', 'expires', 0)
-    local encoded = cjson.encode({
+    local encoded = json_encode({
       jid    = self.jid,
       event  = 'lock_lost',
       worker = worker
@@ -745,29 +745,29 @@ function QlessJob:history(now, what, item)
   -- First, check if there's an old-style history, and update it if there is
   local history = redis.call('hget', QlessJob.ns .. self.jid, 'history')
   if history then
-    history = cjson.decode(history)
+    history = json_decode(history)
     for i, value in ipairs(history) do
       redis.call('rpush', QlessJob.ns .. self.jid .. '-history',
-        cjson.encode({math.floor(value.put), 'put', {q = value.q}}))
+        json_encode({math.floor(value.put), 'put', {q = value.q}}))
 
       -- If there's any popped time
       if value.popped then
         redis.call('rpush', QlessJob.ns .. self.jid .. '-history',
-          cjson.encode({math.floor(value.popped), 'popped',
+          json_encode({math.floor(value.popped), 'popped',
             {worker = value.worker}}))
       end
 
       -- If there's any failure
       if value.failed then
         redis.call('rpush', QlessJob.ns .. self.jid .. '-history',
-          cjson.encode(
+          json_encode(
             {math.floor(value.failed), 'failed', nil}))
       end
 
       -- If it was completed
       if value.done then
         redis.call('rpush', QlessJob.ns .. self.jid .. '-history',
-          cjson.encode(
+          json_encode(
             {math.floor(value.done), 'done', nil}))
       end
     end
@@ -781,7 +781,7 @@ function QlessJob:history(now, what, item)
     local response = {}
     for i, value in ipairs(redis.call('lrange',
       QlessJob.ns .. self.jid .. '-history', 0, -1)) do
-      value = cjson.decode(value)
+      value = json_decode(value)
       local dict = value[3] or {}
       dict['when'] = value[1]
       dict['what'] = value[2]
@@ -801,6 +801,6 @@ function QlessJob:history(now, what, item)
       end
     end
     return redis.call('rpush', QlessJob.ns .. self.jid .. '-history',
-      cjson.encode({math.floor(now), what, item}))
+      json_encode({math.floor(now), what, item}))
   end
 end

--- a/queue.lua
+++ b/queue.lua
@@ -415,7 +415,7 @@ end
 function QlessQueue:put(now, worker, jid, klass, raw_data, delay, ...)
   assert(jid  , 'Put(): Arg "jid" missing')
   assert(klass, 'Put(): Arg "klass" missing')
-  local data = assert(cjson.decode(raw_data),
+  local data = assert(json_decode(raw_data),
     'Put(): Arg "data" missing or not JSON: ' .. tostring(raw_data))
   delay = assert(tonumber(delay),
     'Put(): Arg "delay" not a number: ' .. tostring(delay))
@@ -436,17 +436,17 @@ function QlessQueue:put(now, worker, jid, klass, raw_data, delay, ...)
 
   -- If there are old tags, then we should remove the tags this job has
   if tags then
-    Qless.tag(now, 'remove', jid, unpack(cjson.decode(tags)))
+    Qless.tag(now, 'remove', jid, unpack(json_decode(tags)))
   end
 
   -- Sanity check on optional args
   retries  = assert(tonumber(options['retries']  or retries or 5) ,
     'Put(): Arg "retries" not a number: ' .. tostring(options['retries']))
-  tags     = assert(cjson.decode(options['tags'] or tags or '[]' ),
+  tags     = assert(json_decode(options['tags'] or tags or '[]' ),
     'Put(): Arg "tags" not JSON'          .. tostring(options['tags']))
   priority = assert(tonumber(options['priority'] or priority or 0),
     'Put(): Arg "priority" not a number'  .. tostring(options['priority']))
-  local depends = assert(cjson.decode(options['depends'] or '[]') ,
+  local depends = assert(json_decode(options['depends'] or '[]') ,
     'Put(): Arg "depends" not JSON: '     .. tostring(options['depends']))
 
   -- If the job has old dependencies, determine which dependencies are
@@ -470,7 +470,7 @@ function QlessQueue:put(now, worker, jid, klass, raw_data, delay, ...)
   end
 
   -- Send out a log message
-  Qless.publish('log', cjson.encode({
+  Qless.publish('log', json_encode({
     jid   = jid,
     event = 'put',
     queue = self.name
@@ -496,7 +496,7 @@ function QlessQueue:put(now, worker, jid, klass, raw_data, delay, ...)
     -- to the last owner of the job
     if oldworker ~= worker then
       -- We need to inform whatever worker had that job
-      local encoded = cjson.encode({
+      local encoded = json_encode({
         jid    = jid,
         event  = 'lock_lost',
         worker = oldworker
@@ -520,7 +520,7 @@ function QlessQueue:put(now, worker, jid, klass, raw_data, delay, ...)
 
   -- If we're in the failed state, remove all of our data
   if state == 'failed' then
-    failure = cjson.decode(failure)
+    failure = json_decode(failure)
     -- We need to make this remove it from the failed queues
     redis.call('lrem', 'ql:f:' .. failure.group, 0, jid)
     if redis.call('llen', 'ql:f:' .. failure.group) == 0 then
@@ -540,7 +540,7 @@ function QlessQueue:put(now, worker, jid, klass, raw_data, delay, ...)
     'klass'    , klass,
     'data'     , raw_data,
     'priority' , priority,
-    'tags'     , cjson.encode(tags),
+    'tags'     , json_encode(tags),
     'state'    , ((delay > 0) and 'scheduled') or 'waiting',
     'worker'   , '',
     'expires'  , 0,
@@ -634,7 +634,7 @@ function QlessQueue:recur(now, jid, klass, raw_data, spec, ...)
   assert(jid  , 'RecurringJob On(): Arg "jid" missing')
   assert(klass, 'RecurringJob On(): Arg "klass" missing')
   assert(spec , 'RecurringJob On(): Arg "spec" missing')
-  local data = assert(cjson.decode(raw_data),
+  local data = assert(json_decode(raw_data),
     'RecurringJob On(): Arg "data" not JSON: ' .. tostring(raw_data))
 
   -- At some point in the future, we may have different types of recurring
@@ -657,7 +657,7 @@ function QlessQueue:recur(now, jid, klass, raw_data, spec, ...)
     -- Read in all the optional parameters
     local options = {}
     for i = 3, #arg, 2 do options[arg[i]] = arg[i + 1] end
-    options.tags = assert(cjson.decode(options.tags or '{}'),
+    options.tags = assert(json_decode(options.tags or '{}'),
       'Recur(): Arg "tags" must be JSON string array: ' .. tostring(
         options.tags))
     options.priority = assert(tonumber(options.priority or 0),
@@ -685,7 +685,7 @@ function QlessQueue:recur(now, jid, klass, raw_data, spec, ...)
       'klass'   , klass,
       'data'    , raw_data,
       'priority', options.priority,
-      'tags'    , cjson.encode(options.tags or {}),
+      'tags'    , json_encode(options.tags or {}),
       'state'   , 'recur',
       'queue'   , self.name,
       'type'    , 'interval',
@@ -732,7 +732,7 @@ function QlessQueue:check_recurring(now, count)
     local klass, data, priority, tags, retries, interval, backlog = unpack(
       redis.call('hmget', 'ql:r:' .. jid, 'klass', 'data', 'priority',
         'tags', 'retries', 'interval', 'backlog'))
-    local _tags = cjson.decode(tags)
+    local _tags = json_decode(tags)
     local score = math.floor(tonumber(self.recurring.score(jid)))
     interval = tonumber(interval)
 
@@ -861,7 +861,7 @@ function QlessQueue:invalidate_locks(now, count)
 
       -- Send a message to let the worker know that its lost its lock on
       -- the job
-      local encoded = cjson.encode({
+      local encoded = json_encode({
         jid    = jid,
         event  = 'lock_lost',
         worker = worker
@@ -903,7 +903,7 @@ function QlessQueue:invalidate_locks(now, count)
           'expires', '')
         -- If the failure has not already been set, then set it
         redis.call('hset', QlessJob.ns .. jid,
-        'failure', cjson.encode({
+        'failure', json_encode({
           ['group']   = group,
           ['message'] =
             'Job exhausted retries in queue "' .. self.name .. '"',
@@ -919,7 +919,7 @@ function QlessQueue:invalidate_locks(now, count)
         if redis.call('zscore', 'ql:tracked', jid) ~= false then
           Qless.publish('failed', jid)
         end
-        Qless.publish('log', cjson.encode({
+        Qless.publish('log', json_encode({
           jid     = jid,
           event   = 'failed',
           group   = group,

--- a/queue.lua
+++ b/queue.lua
@@ -247,7 +247,7 @@ function QlessQueue:peek(now, count)
 
   -- With these in place, we can expand this list of jids based on the work
   -- queue itself and the priorities therein
-  table.extend(jids, self.work.peek(count - #jids))
+  table_extend(jids, self.work.peek(count - #jids))
 
   return jids
 end
@@ -322,7 +322,7 @@ function QlessQueue:pop(now, worker, count)
 
   -- With these in place, we can expand this list of jids based on the work
   -- queue itself and the priorities therein
-  table.extend(jids, self.work.peek(count - #jids))
+  table_extend(jids, self.work.peek(count - #jids))
 
   local state
   for index, jid in ipairs(jids) do

--- a/recurring.lua
+++ b/recurring.lua
@@ -18,7 +18,7 @@ function QlessRecurringJob:data()
     retries      = tonumber(job[7]),
     count        = tonumber(job[8]),
     data         = job[9],
-    tags         = cjson.decode(job[10]),
+    tags         = json_decode(job[10]),
     backlog      = tonumber(job[11] or 0)
   }
 end
@@ -50,7 +50,7 @@ function QlessRecurringJob:update(now, ...)
         end
         redis.call('hset', 'ql:r:' .. self.jid, key, value)
       elseif key == 'data' then
-        assert(cjson.decode(value), 'Recur(): Arg "data" is not JSON-encoded: ' .. tostring(value))
+        assert(json_decode(value), 'Recur(): Arg "data" is not JSON-encoded: ' .. tostring(value))
         redis.call('hset', 'ql:r:' .. self.jid, 'data', value)
       elseif key == 'klass' then
         redis.call('hset', 'ql:r:' .. self.jid, 'klass', value)
@@ -85,14 +85,14 @@ function QlessRecurringJob:tag(...)
   -- If the job has been canceled / deleted, then return false
   if tags then
     -- Decode the json blob, convert to dictionary
-    tags = cjson.decode(tags)
+    tags = json_decode(tags)
     local _tags = {}
     for i,v in ipairs(tags) do _tags[v] = true end
 
     -- Otherwise, add the job to the sorted set with that tags
     for i=1,#arg do if _tags[arg[i]] == nil or _tags[arg[i]] == false then table.insert(tags, arg[i]) end end
 
-    tags = cjson.encode(tags)
+    tags = json_encode(tags)
     redis.call('hset', 'ql:r:' .. self.jid, 'tags', tags)
     return tags
   else
@@ -107,7 +107,7 @@ function QlessRecurringJob:untag(...)
   -- If the job has been canceled / deleted, then return false
   if tags then
     -- Decode the json blob, convert to dictionary
-    tags = cjson.decode(tags)
+    tags = json_decode(tags)
     local _tags    = {}
     -- Make a hash
     for i,v in ipairs(tags) do _tags[v] = true end
@@ -117,7 +117,7 @@ function QlessRecurringJob:untag(...)
     local results = {}
     for i, tag in ipairs(tags) do if _tags[tag] then table.insert(results, tag) end end
     -- json encode them, set, and return
-    tags = cjson.encode(results)
+    tags = json_encode(results)
     redis.call('hset', 'ql:r:' .. self.jid, 'tags', tags)
     return tags
   else


### PR DESCRIPTION
Changes to lua scripts to work with Redis 6.0.

The error that we were encountering was `Qless::LuaScriptError: user_script:27: Attempt to modify a readonly table`

I was able to build Andalusia with these changes and work with redis 6.0. 

Changes:
replace `cjson.encode` with `json_encode` local alias
replace `cjson.decode` with `json_decode` local alias
replace `function table.extend(self, other)` with `local function table_extend(self, other)`